### PR TITLE
fix issues related to showing the arch of installed node

### DIFF
--- a/src/nvm/node/node.go
+++ b/src/nvm/node/node.go
@@ -25,7 +25,17 @@ func GetCurrentVersion() (string, string) {
     cmd := exec.Command("node","-p","console.log(process.execPath)")
     str, _ := cmd.Output()
     file := strings.Trim(regexp.MustCompile("undefined").ReplaceAllString(string(str),"")," \n\r")
-    return v, arch.Bit(file)
+	bit := arch.Bit(file)
+	if (bit == "?"){
+		cmd := exec.Command("node", "-e", "console.log(process.arch)" )
+		str, err := cmd.Output()
+		if (string(str) == "x64") {
+			bit := "64"
+		} else {
+			bit := "32"
+		}
+	}
+	return v, bit
   }
   return "Unknown",""
 }


### PR DESCRIPTION
before the fix:
C:\Windows\system32>nvm list

    0.12.2
  * 0.10.36 (Currently using ?-bit executable)

After the fix:

D:\src\nvm-windows\src>src.exe list

    0.12.2
  * 0.10.36 (Currently using 64-bit executable)