### PR TITLE
Fixed for node v4

### DIFF
--- a/nvm.iss
+++ b/nvm.iss
@@ -1,7 +1,7 @@
 #define MyAppName "NVM for Windows"
 #define MyAppShortName "nvm"
 #define MyAppLCShortName "nvm"
-#define MyAppVersion "1.0.6"
+#define MyAppVersion "1.1.0"
 #define MyAppPublisher "Ecor Ventures, LLC"
 #define MyAppURL "http://github.com/coreybutler/nvm"
 #define MyAppExeName "nvm.exe"

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-  NvmVersion = "1.0.6"
+  NvmVersion = "1.1.0"
 )
 
 type Environment struct {

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -120,11 +120,11 @@ func update() {
 }
 
 func CheckVersionExceedsLatest(version string) bool{
-    content := web.GetRemoteTextFile("http://nodejs.org/dist/latest/SHASUMS.txt")
+    content := web.GetRemoteTextFile("http://nodejs.org/dist/latest/SHASUMS256.txt")
     re := regexp.MustCompile("node-v(.+)+msi")
     reg := regexp.MustCompile("node-v|-x.+")
 	latest := reg.ReplaceAllString(re.FindString(content),"")
-	
+
 	if version <= latest {
 		return false
 	} else {
@@ -155,6 +155,14 @@ func install(version string, cpuarch string) {
     cpuarch = arch.Validate(cpuarch)
   }
   
+  // If user specifies "latest" version, find out what version is
+  if version == "latest" {
+    content := web.GetRemoteTextFile("http://nodejs.org/dist/latest/SHASUMS256.txt")
+    re := regexp.MustCompile("node-v(.+)+msi")
+    reg := regexp.MustCompile("node-v|-x.+")
+    version = reg.ReplaceAllString(re.FindString(content),"")
+  }
+
   if CheckVersionExceedsLatest(version) {
 	fmt.Println("Node.js v"+version+" is not yet released or available.")
 	return
@@ -163,14 +171,6 @@ func install(version string, cpuarch string) {
   if cpuarch == "64" && !web.IsNode64bitAvailable(version) {
     fmt.Println("Node.js v"+version+" is only available in 32-bit.")
     return
-  }
-
-  // If user specifies "latest" version, find out what version is
-  if version == "latest" {
-    content := web.GetRemoteTextFile("http://nodejs.org/dist/latest/SHASUMS.txt")
-    re := regexp.MustCompile("node-v(.+)+msi")
-    reg := regexp.MustCompile("node-v|-x.+")
-    version = reg.ReplaceAllString(re.FindString(content),"")
   }
 
   // Check to see if the version is already installed

--- a/src/nvm/node/node.go
+++ b/src/nvm/node/node.go
@@ -25,17 +25,21 @@ func GetCurrentVersion() (string, string) {
     cmd := exec.Command("node","-p","console.log(process.execPath)")
     str, _ := cmd.Output()
     file := strings.Trim(regexp.MustCompile("undefined").ReplaceAllString(string(str),"")," \n\r")
-	bit := arch.Bit(file)
-	if (bit == "?"){
-		cmd := exec.Command("node", "-e", "console.log(process.arch)" )
-		str, err := cmd.Output()
-		if (string(str) == "x64") {
-			bit := "64"
-		} else {
-			bit := "32"
-		}
-	}
-	return v, bit
+    bit := arch.Bit(file)
+    if (bit == "?"){
+      cmd := exec.Command("node", "-e", "console.log(process.arch)" )
+      str, err := cmd.Output()
+      if (err == nil) {
+        if (string(str) == "x64") {
+          bit = "64"
+        } else {
+          bit = "32"
+        }
+      } else {
+        return v, "Unknown"
+      }
+    }
+    return v, bit
   }
   return "Unknown",""
 }

--- a/src/nvm/web/web.go
+++ b/src/nvm/web/web.go
@@ -142,6 +142,23 @@ func GetRemoteTextFile(url string) string {
   return ""
 }
 
+func IsNode64bitAvailable(v string) bool {
+  if v == "latest" {
+    return true
+  }
+
+  // Anything below version 8 doesn't have a 64 bit version
+  vers := strings.Fields(strings.Replace(v,"."," ",-1))
+  main, _ := strconv.ParseInt(vers[0],0,0)
+  minor, _ := strconv.ParseInt(vers[1],0,0)
+  if main == 0 && minor < 8 {
+    return false
+  }
+
+  // TODO: fixme. Assume a 64 bit version exists
+  return true
+}
+
 func getNodeUrl (v string,  vpre string) string {
   url := "http://nodejs.org/dist/v"+v+"/" + vpre + "/node.exe"
   // Check online to see if a 64 bit version exists


### PR DESCRIPTION
New PR for node v4 support. This builds on PR #92 but fixes compile and run time errors. Also Fixes errors in PR #77. 

And fixes the 'nvm install latest' command which was failing because the version available check was checking against the string "latest".

In my limited testing this version seems to build and run correctly, as tested against v0.10.40 and v4.1.0.

Fixes #85 