### PR TITLE
Execute rmdir recursive in command use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,7 @@ bin/*.exe
 bin/*.zip
 bin/nvm/*
 
+tags
+
 !.gitignore
 

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -334,7 +334,7 @@ func use(version string, cpuarch string) {
   // Create or update the symlink
   sym, _ := os.Stat(env.symlink)
   if sym != nil {
-    cmd := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "rmdir", env.symlink)
+    cmd := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "rmdir", "/s", "/q", env.symlink)
     var output bytes.Buffer
     var _stderr bytes.Buffer
     cmd.Stdout = &output


### PR DESCRIPTION
When running "nvm use [version]" the node version is not selected. Why there is already nodejs symlinkpath directory with sub directories and files. It has changed to perform recursive rmdir the "func use ()".