### PR TITLE
Separate 32bit 64bit installations

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -1,133 +1,143 @@
 package main
 
 import (
-  "fmt"
-  "os"
-  "os/exec"
-  "strings"
-  "io/ioutil"
-  "regexp"
-  "bytes"
-  "./nvm/web"
-  "./nvm/arch"
-  "./nvm/file"
-  "./nvm/node"
-  "github.com/olekukonko/tablewriter"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"./nvm/arch"
+	"./nvm/file"
+	"./nvm/node"
+	"./nvm/web"
+	"github.com/olekukonko/tablewriter"
 )
 
 const (
-  NvmVersion = "1.1.1"
+	NvmVersion = "1.1.1"
 )
 
 type Environment struct {
-  settings        string
-  root            string
-  symlink         string
-  arch            string
-  node_mirror     string
-  npm_mirror      string
-  proxy           string
-  originalpath    string
-  originalversion string
+	settings        string
+	root            string
+	symlink         string
+	arch            string
+	node_mirror     string
+	npm_mirror      string
+	proxy           string
+	originalpath    string
+	originalversion string
 }
 
 var env = &Environment{
-  settings: os.Getenv("NVM_HOME")+"\\settings.txt",
-  root: "",
-  symlink: os.Getenv("NVM_SYMLINK"),
-  arch: os.Getenv("PROCESSOR_ARCHITECTURE"),
-  node_mirror: "",
-  npm_mirror: "",
-  proxy: "none",
-  originalpath: "",
-  originalversion: "",
+	settings:        os.Getenv("NVM_HOME") + "\\settings.txt",
+	root:            "",
+	symlink:         os.Getenv("NVM_SYMLINK"),
+	arch:            os.Getenv("PROCESSOR_ARCHITECTURE"),
+	node_mirror:     "",
+	npm_mirror:      "",
+	proxy:           "none",
+	originalpath:    "",
+	originalversion: "",
 }
 
 func main() {
-  args := os.Args
-  detail := ""
-  procarch := arch.Validate(env.arch)
+	args := os.Args
+	detail := ""
+	procarch := arch.Validate(env.arch)
 
-  Setup()
+	Setup()
 
-  // Capture any additional arguments
-  if len(args) > 2 {
-    detail = args[2]
-  }
-  if len(args) > 3 {
-    procarch = args[3]
-  }
-  if len(args) < 2 {
-    help()
-    return
-  }
+	// Capture any additional arguments
+	if len(args) > 2 {
+		detail = args[2]
+	}
+	if len(args) > 3 {
+		procarch = args[3]
+	}
+	if len(args) < 2 {
+		help()
+		return
+	}
 
-  // Run the appropriate method
-  switch args[1] {
-    case "install": install(detail,procarch)
-    case "uninstall": uninstall(detail)
-    case "use": use(detail,procarch)
-    case "list": list(detail)
-    case "ls": list(detail)
-    case "on": enable()
-    case "off": disable()
-    case "root":
-      if len(args) == 3 {
-        updateRootDir(args[2])
-      } else {
-        fmt.Println("\nCurrent Root: "+env.root)
-      }
-    case "version":
-      fmt.Println(NvmVersion)
-    case "v":
-      fmt.Println(NvmVersion)
-    case "arch":
-      if strings.Trim(detail," \r\n") != "" {
-        detail = strings.Trim(detail," \r\n")
-        if detail != "32" && detail != "64" {
-          fmt.Println("\""+detail+"\" is an invalid architecture. Use 32 or 64.")
-          return
-        }
-        env.arch = detail
-        saveSettings()
-        fmt.Println("Default architecture set to "+detail+"-bit.")
-        return
-      }
-      _, a := node.GetCurrentVersion()
-      fmt.Println("System Default: "+env.arch+"-bit.")
-      fmt.Println("Currently Configured: "+a+"-bit.")
-    case "proxy":
-      if detail == "" {
-        fmt.Println("Current proxy: "+env.proxy)
-      } else {
-        env.proxy = detail
-        saveSettings()
-      }
-    case "update": update()
-    default: help()
-  }
+	// Run the appropriate method
+	switch args[1] {
+	case "install":
+		install(detail, procarch)
+	case "uninstall":
+		uninstall(detail)
+	case "use":
+		use(detail, procarch)
+	case "list":
+		list(detail)
+	case "ls":
+		list(detail)
+	case "on":
+		enable()
+	case "off":
+		disable()
+	case "root":
+		if len(args) == 3 {
+			updateRootDir(args[2])
+		} else {
+			fmt.Println("\nCurrent Root: " + env.root)
+		}
+	case "version":
+		fmt.Println(NvmVersion)
+	case "v":
+		fmt.Println(NvmVersion)
+	case "arch":
+		if strings.Trim(detail, " \r\n") != "" {
+			detail = strings.Trim(detail, " \r\n")
+			if detail != "32" && detail != "64" {
+				fmt.Println("\"" + detail + "\" is an invalid architecture. Use 32 or 64.")
+				return
+			}
+			env.arch = detail
+			saveSettings()
+			fmt.Println("Default architecture set to " + detail + "-bit.")
+			return
+		}
+		_, a := node.GetCurrentVersion()
+		fmt.Println("System Default: " + env.arch + "-bit.")
+		fmt.Println("Currently Configured: " + a + "-bit.")
+	case "proxy":
+		if detail == "" {
+			fmt.Println("Current proxy: " + env.proxy)
+		} else {
+			env.proxy = detail
+			saveSettings()
+		}
+	case "update":
+		update()
+	default:
+		help()
+	}
 }
 
 func update() {
-//  cmd := exec.Command("cmd", "/d", "echo", "testing")
-//  var output bytes.Buffer
-//  var _stderr bytes.Buffer
-//  cmd.Stdout = &output
-//  cmd.Stderr = &_stderr
-//  perr := cmd.Run()
-//  if perr != nil {
-//      fmt.Println(fmt.Sprint(perr) + ": " + _stderr.String())
-//      return
-//  }
+	//  cmd := exec.Command("cmd", "/d", "echo", "testing")
+	//  var output bytes.Buffer
+	//  var _stderr bytes.Buffer
+	//  cmd.Stdout = &output
+	//  cmd.Stderr = &_stderr
+	//  perr := cmd.Run()
+	//  if perr != nil {
+	//      fmt.Println(fmt.Sprint(perr) + ": " + _stderr.String())
+	//      return
+	//  }
 }
 
-func CheckVersionExceedsLatest(version string) bool{
-    //content := web.GetRemoteTextFile("http://nodejs.org/dist/latest/SHASUMS256.txt")
-    url := web.GetFullNodeUrl("latest/SHASUMS256.txt");
-    content := web.GetRemoteTextFile(url)
-    re := regexp.MustCompile("node-v(.+)+msi")
-    reg := regexp.MustCompile("node-v|-x.+")
-	latest := reg.ReplaceAllString(re.FindString(content),"")
+func CheckVersionExceedsLatest(version string) bool {
+	//content := web.GetRemoteTextFile("http://nodejs.org/dist/latest/SHASUMS256.txt")
+	url := web.GetFullNodeUrl("latest/SHASUMS256.txt")
+	content := web.GetRemoteTextFile(url)
+	re := regexp.MustCompile("node-v(.+)+msi")
+	reg := regexp.MustCompile("node-v|-x.+")
+	latest := reg.ReplaceAllString(re.FindString(content), "")
 
 	if version <= latest {
 		return false
@@ -137,469 +147,469 @@ func CheckVersionExceedsLatest(version string) bool{
 }
 
 func install(version string, cpuarch string) {
-  if version == "" {
-    fmt.Println("\nInvalid version.")
-    fmt.Println(" ")
-    help()
-    return
-  }
+	if version == "" {
+		fmt.Println("\nInvalid version.")
+		fmt.Println(" ")
+		help()
+		return
+	}
 
-  cpuarch = strings.ToLower(cpuarch)
+	cpuarch = strings.ToLower(cpuarch)
 
-  if cpuarch != "" {
-    if cpuarch != "32" && cpuarch != "64" && cpuarch != "all" {
-      fmt.Println("\""+cpuarch+"\" is not a valid CPU architecture. Must be 32 or 64.")
-      return
-    }
-  } else {
-    cpuarch = env.arch
-  }
+	if cpuarch != "" {
+		if cpuarch != "32" && cpuarch != "64" && cpuarch != "all" {
+			fmt.Println("\"" + cpuarch + "\" is not a valid CPU architecture. Must be 32 or 64.")
+			return
+		}
+	} else {
+		cpuarch = env.arch
+	}
 
-  if cpuarch != "all" {
-    cpuarch = arch.Validate(cpuarch)
-  }
+	if cpuarch != "all" {
+		cpuarch = arch.Validate(cpuarch)
+	}
 
-  // If user specifies "latest" version, find out what version is
-  if version == "latest" {
-    url := web.GetFullNodeUrl("latest/SHASUMS256.txt");
-    content := web.GetRemoteTextFile(url)
-    re := regexp.MustCompile("node-v(.+)+msi")
-    reg := regexp.MustCompile("node-v|-x.+")
-    version = reg.ReplaceAllString(re.FindString(content),"")
-  }
+	// If user specifies "latest" version, find out what version is
+	if version == "latest" {
+		url := web.GetFullNodeUrl("latest/SHASUMS256.txt")
+		content := web.GetRemoteTextFile(url)
+		re := regexp.MustCompile("node-v(.+)+msi")
+		reg := regexp.MustCompile("node-v|-x.+")
+		version = reg.ReplaceAllString(re.FindString(content), "")
+	}
 
-  version = cleanVersion(version)
+	version = cleanVersion(version)
 
-  if CheckVersionExceedsLatest(version) {
-  	fmt.Println("Node.js v"+version+" is not yet released or available.")
-  	return
-  }
+	if CheckVersionExceedsLatest(version) {
+		fmt.Println("Node.js v" + version + " is not yet released or available.")
+		return
+	}
 
-  if cpuarch == "64" && !web.IsNode64bitAvailable(version) {
-    fmt.Println("Node.js v"+version+" is only available in 32-bit.")
-    return
-  }
+	if cpuarch == "64" && !web.IsNode64bitAvailable(version) {
+		fmt.Println("Node.js v" + version + " is only available in 32-bit.")
+		return
+	}
 
-  // Check to see if the version is already installed
-  if !node.IsVersionInstalled(env.root,version,cpuarch) {
+	// Check to see if the version is already installed
+	if !node.IsVersionInstalled(env.root, version, cpuarch) {
 
-    if !node.IsVersionAvailable(version){
-      fmt.Println("Version "+version+" is not available. If you are attempting to download a \"just released\" version,")
-      fmt.Println("it may not be recognized by the nvm service yet (updated hourly). If you feel this is in error and")
-      fmt.Println("you know the version exists, please visit http://github.com/coreybutler/nodedistro and submit a PR.")
-      return
-    }
+		if !node.IsVersionAvailable(version) {
+			fmt.Println("Version " + version + " is not available. If you are attempting to download a \"just released\" version,")
+			fmt.Println("it may not be recognized by the nvm service yet (updated hourly). If you feel this is in error and")
+			fmt.Println("you know the version exists, please visit http://github.com/coreybutler/nodedistro and submit a PR.")
+			return
+		}
 
-    // Make the output directories
-    os.Mkdir(env.root+"\\v"+version,os.ModeDir)
-    os.Mkdir(env.root+"\\v"+version+"\\node_modules",os.ModeDir)
+		// Make the output directories
+		os.Mkdir(env.root+"\\v"+version, os.ModeDir)
+		os.Mkdir(env.root+"\\v"+version+"\\node_modules", os.ModeDir)
 
-    // Download node
-    if (cpuarch == "32" || cpuarch == "all") && !node.IsVersionInstalled(env.root,version,"32") {
-      success := web.GetNodeJS(env.root,version,"32");
-      if !success {
-        os.RemoveAll(env.root+"\\v"+version+"\\node_modules")
-        fmt.Println("Could not download node.js v"+version+" 32-bit executable.")
-        return
-      }
-    }
-    if (cpuarch == "64" || cpuarch == "all") && !node.IsVersionInstalled(env.root,version,"64") {
-      success := web.GetNodeJS(env.root,version,"64");
-      if !success {
-        os.RemoveAll(env.root+"\\v"+version+"\\node_modules")
-        fmt.Println("Could not download node.js v"+version+" 64-bit executable.")
-        return
-      }
-    }
+		// Download node
+		if (cpuarch == "32" || cpuarch == "all") && !node.IsVersionInstalled(env.root, version, "32") {
+			success := web.GetNodeJS(env.root, version, "32")
+			if !success {
+				os.RemoveAll(env.root + "\\v" + version + "\\node_modules")
+				fmt.Println("Could not download node.js v" + version + " 32-bit executable.")
+				return
+			}
+		}
+		if (cpuarch == "64" || cpuarch == "all") && !node.IsVersionInstalled(env.root, version, "64") {
+			success := web.GetNodeJS(env.root, version, "64")
+			if !success {
+				os.RemoveAll(env.root + "\\v" + version + "\\node_modules")
+				fmt.Println("Could not download node.js v" + version + " 64-bit executable.")
+				return
+			}
+		}
 
-    if file.Exists(env.root+"\\v"+version+"\\node_modules\\npm") {
-      return
-    }
+		if file.Exists(env.root + "\\v" + version + "\\node_modules\\npm") {
+			return
+		}
 
-    // If successful, add npm
-    npmv := getNpmVersion(version)
-    success := web.GetNpm(env.root, getNpmVersion(version))
-    if success {
-      fmt.Printf("Installing npm v"+npmv+"...")
+		// If successful, add npm
+		npmv := getNpmVersion(version)
+		success := web.GetNpm(env.root, getNpmVersion(version))
+		if success {
+			fmt.Printf("Installing npm v" + npmv + "...")
 
-      // new temp directory under the nvm root
-      tempDir := env.root + "\\temp"
+			// new temp directory under the nvm root
+			tempDir := env.root + "\\temp"
 
-      // Extract npm to the temp directory
-      file.Unzip(tempDir+"\\npm-v"+npmv+".zip",tempDir+"\\nvm-npm")
+			// Extract npm to the temp directory
+			file.Unzip(tempDir+"\\npm-v"+npmv+".zip", tempDir+"\\nvm-npm")
 
-      // Copy the npm and npm.cmd files to the installation directory
-      os.Rename(tempDir+"\\nvm-npm\\npm-"+npmv+"\\bin\\npm",env.root+"\\v"+version+"\\npm")
-      os.Rename(tempDir+"\\nvm-npm\\npm-"+npmv+"\\bin\\npm.cmd",env.root+"\\v"+version+"\\npm.cmd")
-      os.Rename(tempDir+"\\nvm-npm\\npm-"+npmv,env.root+"\\v"+version+"\\node_modules\\npm")
+			// Copy the npm and npm.cmd files to the installation directory
+			os.Rename(tempDir+"\\nvm-npm\\npm-"+npmv+"\\bin\\npm", env.root+"\\v"+version+"\\npm")
+			os.Rename(tempDir+"\\nvm-npm\\npm-"+npmv+"\\bin\\npm.cmd", env.root+"\\v"+version+"\\npm.cmd")
+			os.Rename(tempDir+"\\nvm-npm\\npm-"+npmv, env.root+"\\v"+version+"\\node_modules\\npm")
 
-      // Remove the temp directory
-      // may consider keep the temp files here
-      os.RemoveAll(tempDir)
+			// Remove the temp directory
+			// may consider keep the temp files here
+			os.RemoveAll(tempDir)
 
-      fmt.Println("\n\nInstallation complete. If you want to use this version, type\n\nnvm use "+version)
-    } else {
-      fmt.Println("Could not download npm for node v"+version+".")
-      fmt.Println("Please visit https://github.com/npm/npm/releases/tag/v"+npmv+" to download npm.")
-      fmt.Println("It should be extracted to "+env.root+"\\v"+version)
-    }
+			fmt.Println("\n\nInstallation complete. If you want to use this version, type\n\nnvm use " + version)
+		} else {
+			fmt.Println("Could not download npm for node v" + version + ".")
+			fmt.Println("Please visit https://github.com/npm/npm/releases/tag/v" + npmv + " to download npm.")
+			fmt.Println("It should be extracted to " + env.root + "\\v" + version)
+		}
 
-    // If this is ever shipped for Mac, it should use homebrew.
-    // If this ever ships on Linux, it should be on bintray so it can use yum, apt-get, etc.
+		// If this is ever shipped for Mac, it should use homebrew.
+		// If this ever ships on Linux, it should be on bintray so it can use yum, apt-get, etc.
 
-    return
-   } else {
-     fmt.Println("Version "+version+" is already installed.")
-     return
-   }
+		return
+	} else {
+		fmt.Println("Version " + version + " is already installed.")
+		return
+	}
 
 }
 
 func uninstall(version string) {
-  // Make sure a version is specified
-  if len(version) == 0 {
-    fmt.Println("Provide the version you want to uninstall.")
-    help()
-    return
-  }
+	// Make sure a version is specified
+	if len(version) == 0 {
+		fmt.Println("Provide the version you want to uninstall.")
+		help()
+		return
+	}
 
-  version = cleanVersion(version)
+	version = cleanVersion(version)
 
-  // Determine if the version exists and skip if it doesn't
-  if node.IsVersionInstalled(env.root,version,"32") || node.IsVersionInstalled(env.root,version,"64") {
-    fmt.Printf("Uninstalling node v"+version+"...")
-    v, _ := node.GetCurrentVersion()
-    if v == version {
-      cmd := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "rmdir", env.symlink)
-      cmd.Run()
-    }
-    e := os.RemoveAll(env.root+"\\v"+version)
-    if e != nil {
-      fmt.Println("Error removing node v"+version)
-      fmt.Println("Manually remove "+env.root+"\\v"+version+".")
-    } else {
-      fmt.Printf(" done")
-    }
-  } else {
-    fmt.Println("node v"+version+" is not installed. Type \"nvm list\" to see what is installed.")
-  }
-  return
+	// Determine if the version exists and skip if it doesn't
+	if node.IsVersionInstalled(env.root, version, "32") || node.IsVersionInstalled(env.root, version, "64") {
+		fmt.Printf("Uninstalling node v" + version + "...")
+		v, _ := node.GetCurrentVersion()
+		if v == version {
+			cmd := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "rmdir", env.symlink)
+			cmd.Run()
+		}
+		e := os.RemoveAll(env.root + "\\v" + version)
+		if e != nil {
+			fmt.Println("Error removing node v" + version)
+			fmt.Println("Manually remove " + env.root + "\\v" + version + ".")
+		} else {
+			fmt.Printf(" done")
+		}
+	} else {
+		fmt.Println("node v" + version + " is not installed. Type \"nvm list\" to see what is installed.")
+	}
+	return
 }
 
 func cleanVersion(version string) string {
-  re := regexp.MustCompile("\\d+.\\d+.\\d+")
-  matched := re.FindString(version)
+	re := regexp.MustCompile("\\d+.\\d+.\\d+")
+	matched := re.FindString(version)
 
-  if len(matched) == 0 {
-    re = regexp.MustCompile("\\d+.\\d+")
-    matched = re.FindString(version)
-    if len(matched) == 0 {
-      matched = version + ".0.0"
-    } else {
-      matched = matched + ".0"
-    }
-    fmt.Println(matched)
-  }
+	if len(matched) == 0 {
+		re = regexp.MustCompile("\\d+.\\d+")
+		matched = re.FindString(version)
+		if len(matched) == 0 {
+			matched = version + ".0.0"
+		} else {
+			matched = matched + ".0"
+		}
+		fmt.Println(matched)
+	}
 
-  return matched
+	return matched
 }
 
 func use(version string, cpuarch string) {
-  if version == "32" || version == "64" {
-    cpuarch = version
-    v, _ := node.GetCurrentVersion()
-    version = v
-  }
+	if version == "32" || version == "64" {
+		cpuarch = version
+		v, _ := node.GetCurrentVersion()
+		version = v
+	}
 
-  cpuarch = arch.Validate(cpuarch)
+	cpuarch = arch.Validate(cpuarch)
 
-  version = cleanVersion(version)
+	version = cleanVersion(version)
 
-  // Make sure the version is installed. If not, warn.
-  if !node.IsVersionInstalled(env.root,version,cpuarch) {
-    fmt.Println("node v"+version+" ("+cpuarch+"-bit) is not installed.")
-    if cpuarch == "32" {
-      if node.IsVersionInstalled(env.root,version,"64") {
-        fmt.Println("\nDid you mean node v"+version+" (64-bit)?\nIf so, type \"nvm use "+version+" 64\" to use it.")
-      }
-    }
-    if cpuarch == "64" {
-      if node.IsVersionInstalled(env.root,version,"32") {
-        fmt.Println("\nDid you mean node v"+version+" (32-bit)?\nIf so, type \"nvm use "+version+" 32\" to use it.")
-      }
-    }
-    return
-  }
+	// Make sure the version is installed. If not, warn.
+	if !node.IsVersionInstalled(env.root, version, cpuarch) {
+		fmt.Println("node v" + version + " (" + cpuarch + "-bit) is not installed.")
+		if cpuarch == "32" {
+			if node.IsVersionInstalled(env.root, version, "64") {
+				fmt.Println("\nDid you mean node v" + version + " (64-bit)?\nIf so, type \"nvm use " + version + " 64\" to use it.")
+			}
+		}
+		if cpuarch == "64" {
+			if node.IsVersionInstalled(env.root, version, "32") {
+				fmt.Println("\nDid you mean node v" + version + " (32-bit)?\nIf so, type \"nvm use " + version + " 32\" to use it.")
+			}
+		}
+		return
+	}
 
-  // Create or update the symlink
-  sym, _ := os.Stat(env.symlink)
-  if sym != nil {
-    cmd := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "rmdir", env.symlink)
-    var output bytes.Buffer
-    var _stderr bytes.Buffer
-    cmd.Stdout = &output
-    cmd.Stderr = &_stderr
-    perr := cmd.Run()
-    if perr != nil {
-        fmt.Println(fmt.Sprint(perr) + ": " + _stderr.String())
-        return
-    }
-  }
+	// Create or update the symlink
+	sym, _ := os.Stat(env.symlink)
+	if sym != nil {
+		cmd := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "rmdir", env.symlink)
+		var output bytes.Buffer
+		var _stderr bytes.Buffer
+		cmd.Stdout = &output
+		cmd.Stderr = &_stderr
+		perr := cmd.Run()
+		if perr != nil {
+			fmt.Println(fmt.Sprint(perr) + ": " + _stderr.String())
+			return
+		}
+	}
 
-  c := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "mklink", "/D", env.symlink, env.root+"\\v"+version)
-  var out bytes.Buffer
-  var stderr bytes.Buffer
-  c.Stdout = &out
-  c.Stderr = &stderr
-  err := c.Run()
-  if err != nil {
-      fmt.Println(fmt.Sprint(err) + ": " + stderr.String())
-      return
-  }
+	c := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "mklink", "/D", env.symlink, env.root+"\\v"+version)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &stderr
+	err := c.Run()
+	if err != nil {
+		fmt.Println(fmt.Sprint(err) + ": " + stderr.String())
+		return
+	}
 
-  // Use the assigned CPU architecture
-  cpuarch = arch.Validate(cpuarch)
-  nodepath   := env.root+"\\v"+version+"\\node.exe"
-  node32path := env.root+"\\v"+version+"\\node32.exe"
-  node64path := env.root+"\\v"+version+"\\node64.exe"
-  node32exists := file.Exists(node32path)
-  node64exists := file.Exists(node64path)
-  nodeexists   := file.Exists(nodepath)
-  if node32exists && cpuarch == "32" { // user wants 32, but node.exe is 64
-    if nodeexists {
-      os.Rename(nodepath, node64path) // node.exe -> node64.exe
-    }
-    os.Rename(node32path, nodepath) // node32.exe -> node.exe
-  }
-  if node64exists && cpuarch == "64" { // user wants 64, but node.exe is 32
-    if nodeexists {
-      os.Rename(nodepath, node32path) // node.exe -> node32.exe
-    }
-    os.Rename(node64path, nodepath) // node64.exe -> node.exe
-  }
-  fmt.Println("Now using node v"+version+" ("+cpuarch+"-bit)")
+	// Use the assigned CPU architecture
+	cpuarch = arch.Validate(cpuarch)
+	nodepath := env.root + "\\v" + version + "\\node.exe"
+	node32path := env.root + "\\v" + version + "\\node32.exe"
+	node64path := env.root + "\\v" + version + "\\node64.exe"
+	node32exists := file.Exists(node32path)
+	node64exists := file.Exists(node64path)
+	nodeexists := file.Exists(nodepath)
+	if node32exists && cpuarch == "32" { // user wants 32, but node.exe is 64
+		if nodeexists {
+			os.Rename(nodepath, node64path) // node.exe -> node64.exe
+		}
+		os.Rename(node32path, nodepath) // node32.exe -> node.exe
+	}
+	if node64exists && cpuarch == "64" { // user wants 64, but node.exe is 32
+		if nodeexists {
+			os.Rename(nodepath, node32path) // node.exe -> node32.exe
+		}
+		os.Rename(node64path, nodepath) // node64.exe -> node.exe
+	}
+	fmt.Println("Now using node v" + version + " (" + cpuarch + "-bit)")
 }
 
 func useArchitecture(a string) {
-  if strings.ContainsAny("32",os.Getenv("PROCESSOR_ARCHITECTURE")) {
-    fmt.Println("This computer only supports 32-bit processing.")
-    return
-  }
-  if a == "32" || a == "64" {
-    env.arch = a
-    saveSettings()
-    fmt.Println("Set to "+a+"-bit mode")
-  } else {
-    fmt.Println("Cannot set architecture to "+a+". Must be 32 or 64 are acceptable values.")
-  }
+	if strings.ContainsAny("32", os.Getenv("PROCESSOR_ARCHITECTURE")) {
+		fmt.Println("This computer only supports 32-bit processing.")
+		return
+	}
+	if a == "32" || a == "64" {
+		env.arch = a
+		saveSettings()
+		fmt.Println("Set to " + a + "-bit mode")
+	} else {
+		fmt.Println("Cannot set architecture to " + a + ". Must be 32 or 64 are acceptable values.")
+	}
 }
 
 func list(listtype string) {
-  if listtype == "" {
-    listtype = "installed"
-  }
-  if listtype != "installed" && listtype != "available" {
-    fmt.Println("\nInvalid list option.\n\nPlease use on of the following\n  - nvm list\n  - nvm list installed\n  - nvm list available")
-    help()
-    return
-  }
+	if listtype == "" {
+		listtype = "installed"
+	}
+	if listtype != "installed" && listtype != "available" {
+		fmt.Println("\nInvalid list option.\n\nPlease use on of the following\n  - nvm list\n  - nvm list installed\n  - nvm list available")
+		help()
+		return
+	}
 
-  if listtype == "installed" {
-    fmt.Println("")
-    inuse, a := node.GetCurrentVersion()
+	if listtype == "installed" {
+		fmt.Println("")
+		inuse, a := node.GetCurrentVersion()
 
-    v := node.GetInstalled(env.root)
-    for i := 0; i < len(v); i++ {
-      version := v[i]
-      isnode, _ := regexp.MatchString("v",version)
-      str := ""
-      if isnode {
-        if "v"+inuse == version {
-          str = str+"  * "
-        } else {
-          str = str+"    "
-        }
-        str = str+regexp.MustCompile("v").ReplaceAllString(version,"")
-        if "v"+inuse == version {
-          str = str+" (Currently using "+a+"-bit executable)"
-//            str = ansi.Color(str,"green:black")
-        }
-        fmt.Printf(str+"\n")
-      }
-    }
-    if len(v) == 0 {
-      fmt.Println("No installations recognized.")
-    }
-  } else {
-    _, lts, current, stable, unstable, _ := node.GetAvailable()
+		v := node.GetInstalled(env.root)
+		for i := 0; i < len(v); i++ {
+			version := v[i]
+			isnode, _ := regexp.MatchString("v", version)
+			str := ""
+			if isnode {
+				if "v"+inuse == version {
+					str = str + "  * "
+				} else {
+					str = str + "    "
+				}
+				str = str + regexp.MustCompile("v").ReplaceAllString(version, "")
+				if "v"+inuse == version {
+					str = str + " (Currently using " + a + "-bit executable)"
+					//            str = ansi.Color(str,"green:black")
+				}
+				fmt.Printf(str + "\n")
+			}
+		}
+		if len(v) == 0 {
+			fmt.Println("No installations recognized.")
+		}
+	} else {
+		_, lts, current, stable, unstable, _ := node.GetAvailable()
 
-    releases := 20
+		releases := 20
 
-    data := make([][]string, releases, releases + 5)
-    for i := 0; i < releases; i++ {
-      release := make([]string, 4, 6)
+		data := make([][]string, releases, releases+5)
+		for i := 0; i < releases; i++ {
+			release := make([]string, 4, 6)
 
-      release[0] = ""
-      release[1] = ""
-      release[2] = ""
-      release[3] = ""
+			release[0] = ""
+			release[1] = ""
+			release[2] = ""
+			release[3] = ""
 
-      if len(current) > i {
-        if len(current[i]) > 0 {
-          release[0] = current[i]
-        }
-      }
+			if len(current) > i {
+				if len(current[i]) > 0 {
+					release[0] = current[i]
+				}
+			}
 
-      if len(lts) > i {
-        if len(lts[i]) > 0 {
-          release[1] = lts[i]
-        }
-      }
+			if len(lts) > i {
+				if len(lts[i]) > 0 {
+					release[1] = lts[i]
+				}
+			}
 
-      if len(stable) > i {
-        if len(stable[i]) > 0 {
-          release[2] = stable[i]
-        }
-      }
+			if len(stable) > i {
+				if len(stable[i]) > 0 {
+					release[2] = stable[i]
+				}
+			}
 
-      if len(unstable) > i {
-        if len(unstable[i]) > 0 {
-          release[3] = unstable[i]
-        }
-      }
+			if len(unstable) > i {
+				if len(unstable[i]) > 0 {
+					release[3] = unstable[i]
+				}
+			}
 
-      data[i] = release
-    }
+			data[i] = release
+		}
 
-    fmt.Println("")
-    table := tablewriter.NewWriter(os.Stdout)
-    table.SetHeader([]string{"   Current  ", "    LTS     ", " Old Stable ", "Old Unstable"})
-    table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
-    table.SetAlignment(tablewriter.ALIGN_CENTER)
-    table.SetCenterSeparator("|")
-    table.AppendBulk(data) // Add Bulk Data
-    table.Render()
+		fmt.Println("")
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{"   Current  ", "    LTS     ", " Old Stable ", "Old Unstable"})
+		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+		table.SetAlignment(tablewriter.ALIGN_CENTER)
+		table.SetCenterSeparator("|")
+		table.AppendBulk(data) // Add Bulk Data
+		table.Render()
 
-    fmt.Println("\nThis is a partial list. For a complete list, visit https://nodejs.org/download/release")
-  }
+		fmt.Println("\nThis is a partial list. For a complete list, visit https://nodejs.org/download/release")
+	}
 }
 
 func enable() {
-  dir := ""
-  files, _ := ioutil.ReadDir(env.root)
-  for _, f := range files {
-    if f.IsDir() {
-      isnode, _ := regexp.MatchString("v",f.Name())
-      if isnode {
-        dir = f.Name()
-      }
-    }
-  }
-  fmt.Println("nvm enabled")
-  if dir != "" {
-    use(strings.Trim(regexp.MustCompile("v").ReplaceAllString(dir,"")," \n\r"),env.arch)
-  } else {
-    fmt.Println("No versions of node.js found. Try installing the latest by typing nvm install latest")
-  }
+	dir := ""
+	files, _ := ioutil.ReadDir(env.root)
+	for _, f := range files {
+		if f.IsDir() {
+			isnode, _ := regexp.MatchString("v", f.Name())
+			if isnode {
+				dir = f.Name()
+			}
+		}
+	}
+	fmt.Println("nvm enabled")
+	if dir != "" {
+		use(strings.Trim(regexp.MustCompile("v").ReplaceAllString(dir, ""), " \n\r"), env.arch)
+	} else {
+		fmt.Println("No versions of node.js found. Try installing the latest by typing nvm install latest")
+	}
 }
 
 func disable() {
-  cmd := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "rmdir", env.symlink)
-  cmd.Run()
-  fmt.Println("nvm disabled")
+	cmd := exec.Command(env.root+"\\elevate.cmd", "cmd", "/C", "rmdir", env.symlink)
+	cmd.Run()
+	fmt.Println("nvm disabled")
 }
 
 func help() {
-  fmt.Println("\nRunning version "+NvmVersion+".")
-  fmt.Println("\nUsage:")
-  fmt.Println(" ")
-  fmt.Println("  nvm arch                     : Show if node is running in 32 or 64 bit mode.")
-  fmt.Println("  nvm install <version> [arch] : The version can be a node.js version or \"latest\" for the latest stable version.")
-  fmt.Println("                                 Optionally specify whether to install the 32 or 64 bit version (defaults to system arch).")
-  fmt.Println("                                 Set [arch] to \"all\" to install 32 AND 64 bit versions.")
-  fmt.Println("  nvm list [available]         : List the node.js installations. Type \"available\" at the end to see what can be installed. Aliased as ls.")
-  fmt.Println("  nvm on                       : Enable node.js version management.")
-  fmt.Println("  nvm off                      : Disable node.js version management.")
-  fmt.Println("  nvm proxy [url]              : Set a proxy to use for downloads. Leave [url] blank to see the current proxy.")
-  fmt.Println("                                 Set [url] to \"none\" to remove the proxy.")
-  fmt.Println("  nvm node_mirror [url]        : Set the node mirror. Defaults to https://nodejs.org/dist/. Leave [url] blank to use default url.")
-  fmt.Println("  nvm npm_mirror [url]         : Set the npm mirror. Defaults to https://github.com/npm/npm/archive/. Leave [url] blank to default url.")
-  fmt.Println("  nvm uninstall <version>      : The version must be a specific version.")
-//  fmt.Println("  nvm update                   : Automatically update nvm to the latest version.")
-  fmt.Println("  nvm use [version] [arch]     : Switch to use the specified version. Optionally specify 32/64bit architecture.")
-  fmt.Println("                                 nvm use <arch> will continue using the selected version, but switch to 32/64 bit mode.")
-  fmt.Println("  nvm root [path]              : Set the directory where nvm should store different versions of node.js.")
-  fmt.Println("                                 If <path> is not set, the current root will be displayed.")
-  fmt.Println("  nvm version                  : Displays the current running version of nvm for Windows. Aliased as v.")
-  fmt.Println(" ")
+	fmt.Println("\nRunning version " + NvmVersion + ".")
+	fmt.Println("\nUsage:")
+	fmt.Println(" ")
+	fmt.Println("  nvm arch                     : Show if node is running in 32 or 64 bit mode.")
+	fmt.Println("  nvm install <version> [arch] : The version can be a node.js version or \"latest\" for the latest stable version.")
+	fmt.Println("                                 Optionally specify whether to install the 32 or 64 bit version (defaults to system arch).")
+	fmt.Println("                                 Set [arch] to \"all\" to install 32 AND 64 bit versions.")
+	fmt.Println("  nvm list [available]         : List the node.js installations. Type \"available\" at the end to see what can be installed. Aliased as ls.")
+	fmt.Println("  nvm on                       : Enable node.js version management.")
+	fmt.Println("  nvm off                      : Disable node.js version management.")
+	fmt.Println("  nvm proxy [url]              : Set a proxy to use for downloads. Leave [url] blank to see the current proxy.")
+	fmt.Println("                                 Set [url] to \"none\" to remove the proxy.")
+	fmt.Println("  nvm node_mirror [url]        : Set the node mirror. Defaults to https://nodejs.org/dist/. Leave [url] blank to use default url.")
+	fmt.Println("  nvm npm_mirror [url]         : Set the npm mirror. Defaults to https://github.com/npm/npm/archive/. Leave [url] blank to default url.")
+	fmt.Println("  nvm uninstall <version>      : The version must be a specific version.")
+	//  fmt.Println("  nvm update                   : Automatically update nvm to the latest version.")
+	fmt.Println("  nvm use [version] [arch]     : Switch to use the specified version. Optionally specify 32/64bit architecture.")
+	fmt.Println("                                 nvm use <arch> will continue using the selected version, but switch to 32/64 bit mode.")
+	fmt.Println("  nvm root [path]              : Set the directory where nvm should store different versions of node.js.")
+	fmt.Println("                                 If <path> is not set, the current root will be displayed.")
+	fmt.Println("  nvm version                  : Displays the current running version of nvm for Windows. Aliased as v.")
+	fmt.Println(" ")
 }
 
 // Given a node.js version, returns the associated npm version
 func getNpmVersion(nodeversion string) string {
 
-  _, _, _, _, _, npm := node.GetAvailable()
+	_, _, _, _, _, npm := node.GetAvailable()
 
-  return npm[nodeversion]
+	return npm[nodeversion]
 }
 
 func updateRootDir(path string) {
-  _, err := os.Stat(path)
-  if err != nil {
-    fmt.Println(path+" does not exist or could not be found.")
-    return
-  }
+	_, err := os.Stat(path)
+	if err != nil {
+		fmt.Println(path + " does not exist or could not be found.")
+		return
+	}
 
-  env.root = path
-  saveSettings()
-  fmt.Println("\nRoot has been set to "+path)
+	env.root = path
+	saveSettings()
+	fmt.Println("\nRoot has been set to " + path)
 }
 
 func saveSettings() {
-  content := "root: "+strings.Trim(env.root," \n\r")+"\r\narch: "+strings.Trim(env.arch," \n\r")+"\r\nproxy: "+strings.Trim(env.proxy," \n\r")+"\r\noriginalpath: "+strings.Trim(env.originalpath," \n\r")+"\r\noriginalversion: "+strings.Trim(env.originalversion," \n\r")
-  content = content + "node_mirror: "+strings.Trim(env.node_mirror," \n\r")+ "npm_mirror: "+strings.Trim(env.npm_mirror," \n\r")
-  ioutil.WriteFile(env.settings, []byte(content), 0644)
+	content := "root: " + strings.Trim(env.root, " \n\r") + "\r\narch: " + strings.Trim(env.arch, " \n\r") + "\r\nproxy: " + strings.Trim(env.proxy, " \n\r") + "\r\noriginalpath: " + strings.Trim(env.originalpath, " \n\r") + "\r\noriginalversion: " + strings.Trim(env.originalversion, " \n\r")
+	content = content + "node_mirror: " + strings.Trim(env.node_mirror, " \n\r") + "npm_mirror: " + strings.Trim(env.npm_mirror, " \n\r")
+	ioutil.WriteFile(env.settings, []byte(content), 0644)
 }
 
 func Setup() {
-  lines, err := file.ReadLines(env.settings)
-  if err != nil {
-    fmt.Println("\nERROR",err)
-    os.Exit(1)
-  }
+	lines, err := file.ReadLines(env.settings)
+	if err != nil {
+		fmt.Println("\nERROR", err)
+		os.Exit(1)
+	}
 
-  // Process each line and extract the value
-  for _, line := range lines {
-    line = strings.Trim(line, " \r\n")
-    if strings.HasPrefix(line, "root:") {
-      env.root = strings.TrimSpace(regexp.MustCompile("^root:").ReplaceAllString(line, ""))
-    } else if strings.HasPrefix(line, "originalpath:") {
-      env.originalpath = strings.TrimSpace(regexp.MustCompile("^originalpath:").ReplaceAllString(line, ""))
-    } else if strings.HasPrefix(line, "originalversion:") {
-      env.originalversion = strings.TrimSpace(regexp.MustCompile("^originalversion:").ReplaceAllString(line, ""))
-    } else if strings.HasPrefix(line, "arch:") {
-      env.arch = strings.TrimSpace(regexp.MustCompile("^arch:").ReplaceAllString(line, ""))
-    } else if strings.HasPrefix(line, "node_mirror:") {
-      env.node_mirror = strings.TrimSpace(regexp.MustCompile("^node_mirror:").ReplaceAllString(line, ""))
-    } else if strings.HasPrefix(line, "npm_mirror:") {
-      env.npm_mirror = strings.TrimSpace(regexp.MustCompile("^npm_mirror:").ReplaceAllString(line, ""))
-    } else if strings.HasPrefix(line, "proxy:") {
-      env.proxy = strings.TrimSpace(regexp.MustCompile("^proxy:").ReplaceAllString(line, ""))
-      if env.proxy != "none" && env.proxy != "" {
-        if strings.ToLower(env.proxy[0:4]) != "http" {
-          env.proxy = "http://"+env.proxy
-        }
-        web.SetProxy(env.proxy)
-      }
-    }
-  }
+	// Process each line and extract the value
+	for _, line := range lines {
+		line = strings.Trim(line, " \r\n")
+		if strings.HasPrefix(line, "root:") {
+			env.root = strings.TrimSpace(regexp.MustCompile("^root:").ReplaceAllString(line, ""))
+		} else if strings.HasPrefix(line, "originalpath:") {
+			env.originalpath = strings.TrimSpace(regexp.MustCompile("^originalpath:").ReplaceAllString(line, ""))
+		} else if strings.HasPrefix(line, "originalversion:") {
+			env.originalversion = strings.TrimSpace(regexp.MustCompile("^originalversion:").ReplaceAllString(line, ""))
+		} else if strings.HasPrefix(line, "arch:") {
+			env.arch = strings.TrimSpace(regexp.MustCompile("^arch:").ReplaceAllString(line, ""))
+		} else if strings.HasPrefix(line, "node_mirror:") {
+			env.node_mirror = strings.TrimSpace(regexp.MustCompile("^node_mirror:").ReplaceAllString(line, ""))
+		} else if strings.HasPrefix(line, "npm_mirror:") {
+			env.npm_mirror = strings.TrimSpace(regexp.MustCompile("^npm_mirror:").ReplaceAllString(line, ""))
+		} else if strings.HasPrefix(line, "proxy:") {
+			env.proxy = strings.TrimSpace(regexp.MustCompile("^proxy:").ReplaceAllString(line, ""))
+			if env.proxy != "none" && env.proxy != "" {
+				if strings.ToLower(env.proxy[0:4]) != "http" {
+					env.proxy = "http://" + env.proxy
+				}
+				web.SetProxy(env.proxy)
+			}
+		}
+	}
 
-  web.SetMirrors(env.node_mirror, env.npm_mirror)
-  env.arch = arch.Validate(env.arch)
+	web.SetMirrors(env.node_mirror, env.npm_mirror)
+	env.arch = arch.Validate(env.arch)
 
-  // Make sure the directories exist
-  _, e := os.Stat(env.root)
-  if e != nil {
-    fmt.Println(env.root+" could not be found or does not exist. Exiting.")
-    return
-  }
+	// Make sure the directories exist
+	_, e := os.Stat(env.root)
+	if e != nil {
+		fmt.Println(env.root + " could not be found or does not exist. Exiting.")
+		return
+	}
 }

--- a/src/nvm/arch/arch.go
+++ b/src/nvm/arch/arch.go
@@ -1,64 +1,64 @@
 package arch
 
 import (
-  //"regexp"
-  "os"
-  //"os/exec"
-  "strings"
-  //"fmt"
-  "encoding/hex"
+	//"regexp"
+	"os"
+	//"os/exec"
+	"strings"
+	//"fmt"
+	"encoding/hex"
 )
 
-func SearchBytesInFile( path string, match string, limit int) bool {
-  // Transform to byte array the string
-  toMatch, err := hex.DecodeString(match);
-  if (err != nil) {
-    return false;
-  }
-  
-  // Opening the file and checking if there is an arror
-  file, err := os.Open(path)
-  if err != nil {
-    return false;
-  }
+func SearchBytesInFile(path string, match string, limit int) bool {
+	// Transform to byte array the string
+	toMatch, err := hex.DecodeString(match)
+	if err != nil {
+		return false
+	}
 
-  // Allocate 1 byte array to perform the match
-  bit := make([]byte, 1);
-  j := 0
-  for i := 0; i < limit; i++ {
-    file.Read(bit);
+	// Opening the file and checking if there is an arror
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
 
-    if bit[0] != toMatch[j] {
-      j = 0;
-    }
-    if bit[0] == toMatch[j] {
-      j++;
-      if (j >= len(toMatch)) {
-        return true;
-      }
-    }
-  }
-  return false;
+	// Allocate 1 byte array to perform the match
+	bit := make([]byte, 1)
+	j := 0
+	for i := 0; i < limit; i++ {
+		file.Read(bit)
+
+		if bit[0] != toMatch[j] {
+			j = 0
+		}
+		if bit[0] == toMatch[j] {
+			j++
+			if j >= len(toMatch) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func Bit(path string) string {
-  is64 := SearchBytesInFile(path, "504500006486", 400);
-  is32 := SearchBytesInFile(path, "504500004C", 400);
-  if is64 {
-    return "64";
-  } else if is32 {
-    return "32";
-  }
-  return "?";
+	is64 := SearchBytesInFile(path, "504500006486", 400)
+	is32 := SearchBytesInFile(path, "504500004C", 400)
+	if is64 {
+		return "64"
+	} else if is32 {
+		return "32"
+	}
+	return "?"
 }
 
-func Validate(str string) (string){
-  if str == "" {
-    str = os.Getenv("PROCESSOR_ARCHITECTURE")
-  }
-  if strings.ContainsAny("64",str) {
-    return "64"
-  } else {
-    return "32"
-  }
+func Validate(str string) string {
+	if str == "" {
+		str = os.Getenv("PROCESSOR_ARCHITECTURE")
+	}
+	if strings.ContainsAny("64", str) {
+		return "64"
+	} else {
+		return "32"
+	}
 }

--- a/src/nvm/file/file.go
+++ b/src/nvm/file/file.go
@@ -1,75 +1,75 @@
 package file
 
-import(
-  "archive/zip"
-  "bufio"
-  "log"
-  "io"
-  "os"
-  "path/filepath"
-  "strings"
+import (
+	"archive/zip"
+	"bufio"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 // Function courtesy http://stackoverflow.com/users/1129149/swtdrgn
 func Unzip(src, dest string) error {
-  r, err := zip.OpenReader(src)
-  if err != nil {
-      return err
-  }
-  defer r.Close()
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
 
-  for _, f := range r.File {
-    rc, err := f.Open()
-    if err != nil {
-        return err
-    }
-    defer rc.Close()
+	for _, f := range r.File {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer rc.Close()
 
-    fpath := filepath.Join(dest, f.Name)
-    if f.FileInfo().IsDir() {
-      os.MkdirAll(fpath, f.Mode())
-    } else {
-      var fdir string
-      if lastIndex := strings.LastIndex(fpath,string(os.PathSeparator)); lastIndex > -1 {
-        fdir = fpath[:lastIndex]
-      }
+		fpath := filepath.Join(dest, f.Name)
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(fpath, f.Mode())
+		} else {
+			var fdir string
+			if lastIndex := strings.LastIndex(fpath, string(os.PathSeparator)); lastIndex > -1 {
+				fdir = fpath[:lastIndex]
+			}
 
-      err = os.MkdirAll(fdir, f.Mode())
-      if err != nil {
-        log.Fatal(err)
-        return err
-      }
-      f, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-      if err != nil {
-        return err
-      }
-      defer f.Close()
+			err = os.MkdirAll(fdir, f.Mode())
+			if err != nil {
+				log.Fatal(err)
+				return err
+			}
+			f, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer f.Close()
 
-      _, err = io.Copy(f, rc)
-      if err != nil {
-        return err
-      }
-    }
-  }
-  return nil
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func ReadLines(path string) ([]string, error) {
-  file, err := os.Open(path)
-  if err != nil {
-    return nil, err
-  }
-  defer file.Close()
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
 
-  var lines []string
-  scanner := bufio.NewScanner(file)
-  for scanner.Scan() {
-    lines = append(lines, scanner.Text())
-  }
-  return lines, scanner.Err()
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
 }
 
 func Exists(filename string) bool {
-  _, err := os.Stat(filename);
-  return err == nil
+	_, err := os.Stat(filename)
+	return err == nil
 }

--- a/src/nvm/node/node.go
+++ b/src/nvm/node/node.go
@@ -44,9 +44,12 @@ func GetCurrentVersion() (string, string) {
 }
 
 func IsVersionInstalled(root string, version string, cpu string) bool {
-	e32 := file.Exists(root + "\\v" + version + "\\node32.exe")
-	e64 := file.Exists(root + "\\v" + version + "\\node64.exe")
+	e32 := file.Exists(root+"\\v"+version+"\\node32.exe") ||
+		file.Exists(root+"\\v"+version+"\\32-bit\\node.exe")
+	e64 := file.Exists(root+"\\v"+version+"\\node64.exe") ||
+		file.Exists(root+"\\v"+version+"\\64-bit\\node.exe")
 	used := file.Exists(root + "\\v" + version + "\\node.exe")
+
 	if cpu == "all" {
 		return ((e32 || e64) && used) || e32 && e64
 	}
@@ -66,6 +69,12 @@ func IsVersionInstalled(root string, version string, cpu string) bool {
 		return e64
 	}
 	return false
+}
+
+func IsUsingOldLayout(root string, version string) bool {
+	return file.Exists(root+"\\v"+version+"\\node32.exe") ||
+		file.Exists(root+"\\v"+version+"\\node64.exe") ||
+		file.Exists(root+"\\v"+version+"\\node.exe")
 }
 
 func IsVersionAvailable(v string) bool {

--- a/src/nvm/node/node.go
+++ b/src/nvm/node/node.go
@@ -1,205 +1,207 @@
 package node
 
-import(
-  "os/exec"
-  "strings"
-  "regexp"
-  "io/ioutil"
-  "encoding/json"
-  "../arch"
-  "../file"
-  "../web"
-  "../semver"
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"../arch"
+	"../file"
+	"../semver"
+	"../web"
 )
 
 /**
  * Returns version, architecture
  */
 func GetCurrentVersion() (string, string) {
-  cmd := exec.Command("node","-v")
-  str, err := cmd.Output()
-  if err == nil {
-    v := strings.Trim(regexp.MustCompile("-.*$").ReplaceAllString(regexp.MustCompile("v").ReplaceAllString(strings.Trim(string(str)," \n\r"),""),"")," \n\r")
-    cmd := exec.Command("node","-p","console.log(process.execPath)")
-    str, _ := cmd.Output()
-    file := strings.Trim(regexp.MustCompile("undefined").ReplaceAllString(string(str),"")," \n\r")
-    bit := arch.Bit(file)
-    if (bit == "?"){
-      cmd := exec.Command("node", "-e", "console.log(process.arch)" )
-      str, err := cmd.Output()
-      if (err == nil) {
-        if (string(str) == "x64") {
-          bit = "64"
-        } else {
-          bit = "32"
-        }
-      } else {
-        return v, "Unknown"
-      }
-    }
-    return v, bit
-  }
-  return "Unknown",""
+	cmd := exec.Command("node", "-v")
+	str, err := cmd.Output()
+	if err == nil {
+		v := strings.Trim(regexp.MustCompile("-.*$").ReplaceAllString(regexp.MustCompile("v").ReplaceAllString(strings.Trim(string(str), " \n\r"), ""), ""), " \n\r")
+		cmd := exec.Command("node", "-p", "console.log(process.execPath)")
+		str, _ := cmd.Output()
+		file := strings.Trim(regexp.MustCompile("undefined").ReplaceAllString(string(str), ""), " \n\r")
+		bit := arch.Bit(file)
+		if bit == "?" {
+			cmd := exec.Command("node", "-e", "console.log(process.arch)")
+			str, err := cmd.Output()
+			if err == nil {
+				if string(str) == "x64" {
+					bit = "64"
+				} else {
+					bit = "32"
+				}
+			} else {
+				return v, "Unknown"
+			}
+		}
+		return v, bit
+	}
+	return "Unknown", ""
 }
 
 func IsVersionInstalled(root string, version string, cpu string) bool {
-  e32 := file.Exists(root+"\\v"+version+"\\node32.exe")
-  e64 := file.Exists(root+"\\v"+version+"\\node64.exe")
-  used := file.Exists(root+"\\v"+version+"\\node.exe")
-  if cpu == "all" {
-    return ((e32 || e64) && used) || e32 && e64
-  }
-  if file.Exists(root+"\\v"+version+"\\node"+cpu+".exe") {
-    return true
-  }
-  if ((e32||e64) && used) || (e32 && e64) {
-    return true
-  }
-  if !e32 && !e64 && used && arch.Validate(cpu) == arch.Bit(root+"\\v"+version+"\\node.exe") {
-    return true
-  }
-  if cpu == "32" {
-    return e32
-  }
-  if cpu == "64" {
-    return e64
-  }
-  return false
+	e32 := file.Exists(root + "\\v" + version + "\\node32.exe")
+	e64 := file.Exists(root + "\\v" + version + "\\node64.exe")
+	used := file.Exists(root + "\\v" + version + "\\node.exe")
+	if cpu == "all" {
+		return ((e32 || e64) && used) || e32 && e64
+	}
+	if file.Exists(root + "\\v" + version + "\\node" + cpu + ".exe") {
+		return true
+	}
+	if ((e32 || e64) && used) || (e32 && e64) {
+		return true
+	}
+	if !e32 && !e64 && used && arch.Validate(cpu) == arch.Bit(root+"\\v"+version+"\\node.exe") {
+		return true
+	}
+	if cpu == "32" {
+		return e32
+	}
+	if cpu == "64" {
+		return e64
+	}
+	return false
 }
 
 func IsVersionAvailable(v string) bool {
-  // Check the service to make sure the version is available
-  avail, _, _, _, _, _ := GetAvailable()
+	// Check the service to make sure the version is available
+	avail, _, _, _, _, _ := GetAvailable()
 
-  for _, b := range avail {
-    if b == v {
-      return true
-    }
-  }
-  return false
+	for _, b := range avail {
+		if b == v {
+			return true
+		}
+	}
+	return false
 }
 
 func GetInstalled(root string) []string {
-  list := make([]string,0)
-  files, _ := ioutil.ReadDir(root)
-  for i := len(files) - 1; i >= 0; i-- {
-    if files[i].IsDir() {
-      isnode, _ := regexp.MatchString("v",files[i].Name())
-      if isnode {
-        list = append(list,files[i].Name())
-      }
-    }
-  }
-  return list
+	list := make([]string, 0)
+	files, _ := ioutil.ReadDir(root)
+	for i := len(files) - 1; i >= 0; i-- {
+		if files[i].IsDir() {
+			isnode, _ := regexp.MatchString("v", files[i].Name())
+			if isnode {
+				list = append(list, files[i].Name())
+			}
+		}
+	}
+	return list
 }
 
 // Sorting
 type BySemanticVersion []string
+
 func (s BySemanticVersion) Len() int {
-    return len(s)
+	return len(s)
 }
 func (s BySemanticVersion) Swap(i, j int) {
-    s[i], s[j] = s[j], s[i]
+	s[i], s[j] = s[j], s[i]
 }
 func (s BySemanticVersion) Less(i, j int) bool {
-  v1, _ := semver.New(s[i])
-  v2, _ := semver.New(s[j])
-  return v1.GTE(v2)
+	v1, _ := semver.New(s[i])
+	v2, _ := semver.New(s[j])
+	return v1.GTE(v2)
 }
 
 // Identifies a version as "LTS"
 func isLTS(element map[string]interface{}) bool {
-  switch datatype := element["lts"].(type) {
-    case bool:
-      return datatype
-    case string:
-      return true
-  }
-  return false
+	switch datatype := element["lts"].(type) {
+	case bool:
+		return datatype
+	case string:
+		return true
+	}
+	return false
 }
 
 // Identifies a version as "current"
 func isCurrent(element map[string]interface{}) bool {
-  if isLTS(element) {
-    return false
-  }
+	if isLTS(element) {
+		return false
+	}
 
-  version, _ := semver.New(element["version"].(string)[1:])
-  benchmark, _ := semver.New("1.0.0")
+	version, _ := semver.New(element["version"].(string)[1:])
+	benchmark, _ := semver.New("1.0.0")
 
-  if version.LT(benchmark) {
-    return false
-  }
+	if version.LT(benchmark) {
+		return false
+	}
 
-  return version.Major%2 == 0
+	return version.Major%2 == 0
 }
 
 // Identifies a stable old version.
 func isStable(element map[string]interface{}) bool {
-  if isCurrent(element) {
-    return false
-  }
+	if isCurrent(element) {
+		return false
+	}
 
-  version, _ := semver.New(element["version"].(string)[1:])
+	version, _ := semver.New(element["version"].(string)[1:])
 
-  if (version.Major != 0) {
-    return false
-  }
+	if version.Major != 0 {
+		return false
+	}
 
-  return version.Minor%2 == 0
+	return version.Minor%2 == 0
 }
 
 // Identifies an unstable old version.
 func isUnstable(element map[string]interface{}) bool {
-  if isStable(element) {
-    return false
-  }
+	if isStable(element) {
+		return false
+	}
 
-  version, _ := semver.New(element["version"].(string)[1:])
+	version, _ := semver.New(element["version"].(string)[1:])
 
-  if (version.Major != 0) {
-    return false
-  }
+	if version.Major != 0 {
+		return false
+	}
 
-  return version.Minor%2 != 0
+	return version.Minor%2 != 0
 }
 
 // Retrieve the remotely available versions
 func GetAvailable() ([]string, []string, []string, []string, []string, map[string]string) {
-  all := make([]string,0)
-  lts := make([]string,0)
-  current := make([]string,0)
-  stable := make([]string,0)
-  unstable := make([]string,0)
-  npm := make(map[string]string)
-  url := web.GetFullNodeUrl("index.json")
+	all := make([]string, 0)
+	lts := make([]string, 0)
+	current := make([]string, 0)
+	stable := make([]string, 0)
+	unstable := make([]string, 0)
+	npm := make(map[string]string)
+	url := web.GetFullNodeUrl("index.json")
 
-  // Check the service to make sure the version is available
-  text := web.GetRemoteTextFile(url)
+	// Check the service to make sure the version is available
+	text := web.GetRemoteTextFile(url)
 
-  // Parse
-  var data = make([]map[string]interface{}, 0)
-  json.Unmarshal([]byte(text), &data);
+	// Parse
+	var data = make([]map[string]interface{}, 0)
+	json.Unmarshal([]byte(text), &data)
 
-  for _, element := range data {
+	for _, element := range data {
 
-    var version = element["version"].(string)[1:]
-    all = append(all, version)
+		var version = element["version"].(string)[1:]
+		all = append(all, version)
 
-    if val, ok := element["npm"].(string); ok {
-      npm[version] = val
-    }
+		if val, ok := element["npm"].(string); ok {
+			npm[version] = val
+		}
 
-    if isLTS(element) {
-      lts = append(lts, version)
-    } else if isCurrent(element) {
-      current = append(current, version)
-    } else if isStable(element) {
-      stable = append(stable, version)
-    } else if isUnstable(element) {
-      unstable = append(unstable, version)
-    }
-  }
+		if isLTS(element) {
+			lts = append(lts, version)
+		} else if isCurrent(element) {
+			current = append(current, version)
+		} else if isStable(element) {
+			stable = append(stable, version)
+		} else if isUnstable(element) {
+			unstable = append(unstable, version)
+		}
+	}
 
-  return all, lts, current, stable, unstable, npm
+	return all, lts, current, stable, unstable, npm
 }

--- a/src/nvm/semver/semver.go
+++ b/src/nvm/semver/semver.go
@@ -5,78 +5,78 @@
 package semver
 
 import (
-  "errors"
-  "fmt"
-  "strconv"
-  "strings"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 )
 
 const (
-  numbers  string = "0123456789"
-  alphas          = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
-  alphanum        = alphas + numbers
-  dot             = "."
-  hyphen          = "-"
-  plus            = "+"
+	numbers  string = "0123456789"
+	alphas          = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+	alphanum        = alphas + numbers
+	dot             = "."
+	hyphen          = "-"
+	plus            = "+"
 )
 
 // Latest fully supported spec version
 var SPEC_VERSION = Version{
-  Major: 2,
-  Minor: 0,
-  Patch: 0,
+	Major: 2,
+	Minor: 0,
+	Patch: 0,
 }
 
 type Version struct {
-  Major uint64
-  Minor uint64
-  Patch uint64
-  Pre   []*PRVersion
-  Build []string //No Precendence
+	Major uint64
+	Minor uint64
+	Patch uint64
+	Pre   []*PRVersion
+	Build []string //No Precendence
 }
 
 // Version to string
 func (v *Version) String() string {
-  versionArray := []string{
-    strconv.FormatUint(v.Major, 10),
-    dot,
-    strconv.FormatUint(v.Minor, 10),
-    dot,
-    strconv.FormatUint(v.Patch, 10),
-  }
-  if len(v.Pre) > 0 {
-    versionArray = append(versionArray, hyphen)
-    for i, pre := range v.Pre {
-      if i > 0 {
-        versionArray = append(versionArray, dot)
-      }
-      versionArray = append(versionArray, pre.String())
-    }
-  }
-  if len(v.Build) > 0 {
-    versionArray = append(versionArray, plus, strings.Join(v.Build, dot))
-  }
-  return strings.Join(versionArray, "")
+	versionArray := []string{
+		strconv.FormatUint(v.Major, 10),
+		dot,
+		strconv.FormatUint(v.Minor, 10),
+		dot,
+		strconv.FormatUint(v.Patch, 10),
+	}
+	if len(v.Pre) > 0 {
+		versionArray = append(versionArray, hyphen)
+		for i, pre := range v.Pre {
+			if i > 0 {
+				versionArray = append(versionArray, dot)
+			}
+			versionArray = append(versionArray, pre.String())
+		}
+	}
+	if len(v.Build) > 0 {
+		versionArray = append(versionArray, plus, strings.Join(v.Build, dot))
+	}
+	return strings.Join(versionArray, "")
 }
 
 // Checks if v is greater than o.
 func (v *Version) GT(o *Version) bool {
-  return (v.Compare(o) == 1)
+	return (v.Compare(o) == 1)
 }
 
 // Checks if v is greater than or equal to o.
 func (v *Version) GTE(o *Version) bool {
-  return (v.Compare(o) >= 0)
+	return (v.Compare(o) >= 0)
 }
 
 // Checks if v is less than o.
 func (v *Version) LT(o *Version) bool {
-  return (v.Compare(o) == -1)
+	return (v.Compare(o) == -1)
 }
 
 // Checks if v is less than or equal to o.
 func (v *Version) LTE(o *Version) bool {
-  return (v.Compare(o) <= 0)
+	return (v.Compare(o) <= 0)
 }
 
 // Compares Versions v to o:
@@ -84,241 +84,241 @@ func (v *Version) LTE(o *Version) bool {
 // 0 == v is equal to o
 // 1 == v is greater than o
 func (v *Version) Compare(o *Version) int {
-  if v.Major != o.Major {
-    if v.Major > o.Major {
-      return 1
-    } else {
-      return -1
-    }
-  }
-  if v.Minor != o.Minor {
-    if v.Minor > o.Minor {
-      return 1
-    } else {
-      return -1
-    }
-  }
-  if v.Patch != o.Patch {
-    if v.Patch > o.Patch {
-      return 1
-    } else {
-      return -1
-    }
-  }
+	if v.Major != o.Major {
+		if v.Major > o.Major {
+			return 1
+		} else {
+			return -1
+		}
+	}
+	if v.Minor != o.Minor {
+		if v.Minor > o.Minor {
+			return 1
+		} else {
+			return -1
+		}
+	}
+	if v.Patch != o.Patch {
+		if v.Patch > o.Patch {
+			return 1
+		} else {
+			return -1
+		}
+	}
 
-  // Quick comparison if a version has no prerelease versions
-  if len(v.Pre) == 0 && len(o.Pre) == 0 {
-    return 0
-  } else if len(v.Pre) == 0 && len(o.Pre) > 0 {
-    return 1
-  } else if len(v.Pre) > 0 && len(o.Pre) == 0 {
-    return -1
-  } else {
+	// Quick comparison if a version has no prerelease versions
+	if len(v.Pre) == 0 && len(o.Pre) == 0 {
+		return 0
+	} else if len(v.Pre) == 0 && len(o.Pre) > 0 {
+		return 1
+	} else if len(v.Pre) > 0 && len(o.Pre) == 0 {
+		return -1
+	} else {
 
-    i := 0
-    for ; i < len(v.Pre) && i < len(o.Pre); i++ {
-      if comp := v.Pre[i].Compare(o.Pre[i]); comp == 0 {
-        continue
-      } else if comp == 1 {
-        return 1
-      } else {
-        return -1
-      }
-    }
+		i := 0
+		for ; i < len(v.Pre) && i < len(o.Pre); i++ {
+			if comp := v.Pre[i].Compare(o.Pre[i]); comp == 0 {
+				continue
+			} else if comp == 1 {
+				return 1
+			} else {
+				return -1
+			}
+		}
 
-    // If all pr versions are the equal but one has further prversion, this one greater
-    if i == len(v.Pre) && i == len(o.Pre) {
-      return 0
-    } else if i == len(v.Pre) && i < len(o.Pre) {
-      return -1
-    } else {
-      return 1
-    }
+		// If all pr versions are the equal but one has further prversion, this one greater
+		if i == len(v.Pre) && i == len(o.Pre) {
+			return 0
+		} else if i == len(v.Pre) && i < len(o.Pre) {
+			return -1
+		} else {
+			return 1
+		}
 
-  }
+	}
 }
 
 // Validates v and returns error in case
 func (v *Version) Validate() error {
-  // Major, Minor, Patch already validated using uint64
+	// Major, Minor, Patch already validated using uint64
 
-  if len(v.Pre) > 0 {
-    for _, pre := range v.Pre {
-      if !pre.IsNum { //Numeric prerelease versions already uint64
-        if len(pre.VersionStr) == 0 {
-          return fmt.Errorf("Prerelease can not be empty %q", pre.VersionStr)
-        }
-        if !containsOnly(pre.VersionStr, alphanum) {
-          return fmt.Errorf("Invalid character(s) found in prerelease %q", pre.VersionStr)
-        }
-      }
-    }
-  }
+	if len(v.Pre) > 0 {
+		for _, pre := range v.Pre {
+			if !pre.IsNum { //Numeric prerelease versions already uint64
+				if len(pre.VersionStr) == 0 {
+					return fmt.Errorf("Prerelease can not be empty %q", pre.VersionStr)
+				}
+				if !containsOnly(pre.VersionStr, alphanum) {
+					return fmt.Errorf("Invalid character(s) found in prerelease %q", pre.VersionStr)
+				}
+			}
+		}
+	}
 
-  if len(v.Build) > 0 {
-    for _, build := range v.Build {
-      if len(build) == 0 {
-        return fmt.Errorf("Build meta data can not be empty %q", build)
-      }
-      if !containsOnly(build, alphanum) {
-        return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
-      }
-    }
-  }
+	if len(v.Build) > 0 {
+		for _, build := range v.Build {
+			if len(build) == 0 {
+				return fmt.Errorf("Build meta data can not be empty %q", build)
+			}
+			if !containsOnly(build, alphanum) {
+				return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+			}
+		}
+	}
 
-  return nil
+	return nil
 }
 
 // Alias for Parse, parses version string and returns a validated Version or error
 func New(s string) (*Version, error) {
-  return Parse(s)
+	return Parse(s)
 }
 
 // Parses version string and returns a validated Version or error
 func Parse(s string) (*Version, error) {
-  if len(s) == 0 {
-    return nil, errors.New("Version string empty")
-  }
+	if len(s) == 0 {
+		return nil, errors.New("Version string empty")
+	}
 
-  // Split into major.minor.(patch+pr+meta)
-  parts := strings.SplitN(s, ".", 3)
-  if len(parts) != 3 {
-    return nil, errors.New("No Major.Minor.Patch elements found")
-  }
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return nil, errors.New("No Major.Minor.Patch elements found")
+	}
 
-  // Major
-  if !containsOnly(parts[0], numbers) {
-    return nil, fmt.Errorf("Invalid character(s) found in major number %q", parts[0])
-  }
-  if hasLeadingZeroes(parts[0]) {
-    return nil, fmt.Errorf("Major number must not contain leading zeroes %q", parts[0])
-  }
-  major, err := strconv.ParseUint(parts[0], 10, 64)
-  if err != nil {
-    return nil, err
-  }
+	// Major
+	if !containsOnly(parts[0], numbers) {
+		return nil, fmt.Errorf("Invalid character(s) found in major number %q", parts[0])
+	}
+	if hasLeadingZeroes(parts[0]) {
+		return nil, fmt.Errorf("Major number must not contain leading zeroes %q", parts[0])
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
 
-  // Minor
-  if !containsOnly(parts[1], numbers) {
-    return nil, fmt.Errorf("Invalid character(s) found in minor number %q", parts[1])
-  }
-  if hasLeadingZeroes(parts[1]) {
-    return nil, fmt.Errorf("Minor number must not contain leading zeroes %q", parts[1])
-  }
-  minor, err := strconv.ParseUint(parts[1], 10, 64)
-  if err != nil {
-    return nil, err
-  }
+	// Minor
+	if !containsOnly(parts[1], numbers) {
+		return nil, fmt.Errorf("Invalid character(s) found in minor number %q", parts[1])
+	}
+	if hasLeadingZeroes(parts[1]) {
+		return nil, fmt.Errorf("Minor number must not contain leading zeroes %q", parts[1])
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return nil, err
+	}
 
-  preIndex := strings.Index(parts[2], "-")
-  buildIndex := strings.Index(parts[2], "+")
+	preIndex := strings.Index(parts[2], "-")
+	buildIndex := strings.Index(parts[2], "+")
 
-  // Determine last index of patch version (first of pre or build versions)
-  var subVersionIndex int
-  if preIndex != -1 && buildIndex == -1 {
-    subVersionIndex = preIndex
-  } else if preIndex == -1 && buildIndex != -1 {
-    subVersionIndex = buildIndex
-  } else if preIndex == -1 && buildIndex == -1 {
-    subVersionIndex = len(parts[2])
-  } else {
-    // if there is no actual prversion but a hyphen inside the build meta data
-    if buildIndex < preIndex {
-      subVersionIndex = buildIndex
-      preIndex = -1 // Build meta data before preIndex found implicates there are no prerelease versions
-    } else {
-      subVersionIndex = preIndex
-    }
-  }
+	// Determine last index of patch version (first of pre or build versions)
+	var subVersionIndex int
+	if preIndex != -1 && buildIndex == -1 {
+		subVersionIndex = preIndex
+	} else if preIndex == -1 && buildIndex != -1 {
+		subVersionIndex = buildIndex
+	} else if preIndex == -1 && buildIndex == -1 {
+		subVersionIndex = len(parts[2])
+	} else {
+		// if there is no actual prversion but a hyphen inside the build meta data
+		if buildIndex < preIndex {
+			subVersionIndex = buildIndex
+			preIndex = -1 // Build meta data before preIndex found implicates there are no prerelease versions
+		} else {
+			subVersionIndex = preIndex
+		}
+	}
 
-  if !containsOnly(parts[2][:subVersionIndex], numbers) {
-    return nil, fmt.Errorf("Invalid character(s) found in patch number %q", parts[2][:subVersionIndex])
-  }
-  if hasLeadingZeroes(parts[2][:subVersionIndex]) {
-    return nil, fmt.Errorf("Patch number must not contain leading zeroes %q", parts[2][:subVersionIndex])
-  }
-  patch, err := strconv.ParseUint(parts[2][:subVersionIndex], 10, 64)
-  if err != nil {
-    return nil, err
-  }
-  v := &Version{}
-  v.Major = major
-  v.Minor = minor
-  v.Patch = patch
+	if !containsOnly(parts[2][:subVersionIndex], numbers) {
+		return nil, fmt.Errorf("Invalid character(s) found in patch number %q", parts[2][:subVersionIndex])
+	}
+	if hasLeadingZeroes(parts[2][:subVersionIndex]) {
+		return nil, fmt.Errorf("Patch number must not contain leading zeroes %q", parts[2][:subVersionIndex])
+	}
+	patch, err := strconv.ParseUint(parts[2][:subVersionIndex], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	v := &Version{}
+	v.Major = major
+	v.Minor = minor
+	v.Patch = patch
 
-  // There are PreRelease versions
-  if preIndex != -1 {
-    var preRels string
-    if buildIndex != -1 {
-      preRels = parts[2][subVersionIndex+1 : buildIndex]
-    } else {
-      preRels = parts[2][subVersionIndex+1:]
-    }
-    prparts := strings.Split(preRels, ".")
-    for _, prstr := range prparts {
-      parsedPR, err := NewPRVersion(prstr)
-      if err != nil {
-        return nil, err
-      }
-      v.Pre = append(v.Pre, parsedPR)
-    }
-  }
+	// There are PreRelease versions
+	if preIndex != -1 {
+		var preRels string
+		if buildIndex != -1 {
+			preRels = parts[2][subVersionIndex+1 : buildIndex]
+		} else {
+			preRels = parts[2][subVersionIndex+1:]
+		}
+		prparts := strings.Split(preRels, ".")
+		for _, prstr := range prparts {
+			parsedPR, err := NewPRVersion(prstr)
+			if err != nil {
+				return nil, err
+			}
+			v.Pre = append(v.Pre, parsedPR)
+		}
+	}
 
-  // There is build meta data
-  if buildIndex != -1 {
-    buildStr := parts[2][buildIndex+1:]
-    buildParts := strings.Split(buildStr, ".")
-    for _, str := range buildParts {
-      if len(str) == 0 {
-        return nil, errors.New("Build meta data is empty")
-      }
-      if !containsOnly(str, alphanum) {
-        return nil, fmt.Errorf("Invalid character(s) found in build meta data %q", str)
-      }
-      v.Build = append(v.Build, str)
-    }
-  }
+	// There is build meta data
+	if buildIndex != -1 {
+		buildStr := parts[2][buildIndex+1:]
+		buildParts := strings.Split(buildStr, ".")
+		for _, str := range buildParts {
+			if len(str) == 0 {
+				return nil, errors.New("Build meta data is empty")
+			}
+			if !containsOnly(str, alphanum) {
+				return nil, fmt.Errorf("Invalid character(s) found in build meta data %q", str)
+			}
+			v.Build = append(v.Build, str)
+		}
+	}
 
-  return v, nil
+	return v, nil
 }
 
 // PreRelease Version
 type PRVersion struct {
-  VersionStr string
-  VersionNum uint64
-  IsNum      bool
+	VersionStr string
+	VersionNum uint64
+	IsNum      bool
 }
 
 // Creates a new valid prerelease version
 func NewPRVersion(s string) (*PRVersion, error) {
-  if len(s) == 0 {
-    return nil, errors.New("Prerelease is empty")
-  }
-  v := &PRVersion{}
-  if containsOnly(s, numbers) {
-    if hasLeadingZeroes(s) {
-      return nil, fmt.Errorf("Numeric PreRelease version must not contain leading zeroes %q", s)
-    }
-    num, err := strconv.ParseUint(s, 10, 64)
+	if len(s) == 0 {
+		return nil, errors.New("Prerelease is empty")
+	}
+	v := &PRVersion{}
+	if containsOnly(s, numbers) {
+		if hasLeadingZeroes(s) {
+			return nil, fmt.Errorf("Numeric PreRelease version must not contain leading zeroes %q", s)
+		}
+		num, err := strconv.ParseUint(s, 10, 64)
 
-    // Might never be hit, but just in case
-    if err != nil {
-      return nil, err
-    }
-    v.VersionNum = num
-    v.IsNum = true
-  } else if containsOnly(s, alphanum) {
-    v.VersionStr = s
-    v.IsNum = false
-  } else {
-    return nil, fmt.Errorf("Invalid character(s) found in prerelease %q", s)
-  }
-  return v, nil
+		// Might never be hit, but just in case
+		if err != nil {
+			return nil, err
+		}
+		v.VersionNum = num
+		v.IsNum = true
+	} else if containsOnly(s, alphanum) {
+		v.VersionStr = s
+		v.IsNum = false
+	} else {
+		return nil, fmt.Errorf("Invalid character(s) found in prerelease %q", s)
+	}
+	return v, nil
 }
 
 // Is pre release version numeric?
 func (v *PRVersion) IsNumeric() bool {
-  return v.IsNum
+	return v.IsNum
 }
 
 // Compares PreRelease Versions v to o:
@@ -326,54 +326,54 @@ func (v *PRVersion) IsNumeric() bool {
 // 0 == v is equal to o
 // 1 == v is greater than o
 func (v *PRVersion) Compare(o *PRVersion) int {
-  if v.IsNum && !o.IsNum {
-    return -1
-  } else if !v.IsNum && o.IsNum {
-    return 1
-  } else if v.IsNum && o.IsNum {
-    if v.VersionNum == o.VersionNum {
-      return 0
-    } else if v.VersionNum > o.VersionNum {
-      return 1
-    } else {
-      return -1
-    }
-  } else { // both are Alphas
-    if v.VersionStr == o.VersionStr {
-      return 0
-    } else if v.VersionStr > o.VersionStr {
-      return 1
-    } else {
-      return -1
-    }
-  }
+	if v.IsNum && !o.IsNum {
+		return -1
+	} else if !v.IsNum && o.IsNum {
+		return 1
+	} else if v.IsNum && o.IsNum {
+		if v.VersionNum == o.VersionNum {
+			return 0
+		} else if v.VersionNum > o.VersionNum {
+			return 1
+		} else {
+			return -1
+		}
+	} else { // both are Alphas
+		if v.VersionStr == o.VersionStr {
+			return 0
+		} else if v.VersionStr > o.VersionStr {
+			return 1
+		} else {
+			return -1
+		}
+	}
 }
 
 // PreRelease version to string
 func (v *PRVersion) String() string {
-  if v.IsNum {
-    return strconv.FormatUint(v.VersionNum, 10)
-  }
-  return v.VersionStr
+	if v.IsNum {
+		return strconv.FormatUint(v.VersionNum, 10)
+	}
+	return v.VersionStr
 }
 
 func containsOnly(s string, set string) bool {
-  return strings.IndexFunc(s, func(r rune) bool {
-    return !strings.ContainsRune(set, r)
-  }) == -1
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
 }
 
 func hasLeadingZeroes(s string) bool {
-  return len(s) > 1 && s[0] == '0'
+	return len(s) > 1 && s[0] == '0'
 }
 
 // Creates a new valid build version
 func NewBuildVersion(s string) (string, error) {
-  if len(s) == 0 {
-    return "", errors.New("Buildversion is empty")
-  }
-  if !containsOnly(s, alphanum) {
-    return "", fmt.Errorf("Invalid character(s) found in build meta data %q", s)
-  }
-  return s, nil
+	if len(s) == 0 {
+		return "", errors.New("Buildversion is empty")
+	}
+	if !containsOnly(s, alphanum) {
+		return "", fmt.Errorf("Invalid character(s) found in build meta data %q", s)
+	}
+	return s, nil
 }

--- a/src/nvm/web/web.go
+++ b/src/nvm/web/web.go
@@ -109,7 +109,7 @@ func GetNodeJS(root string, v string, a string) bool {
 		//No url should mean this version/arch isn't available
 		fmt.Println("Node.js v" + v + " " + a + "bit isn't available right now.")
 	} else {
-		fileName := root + "\\v" + v + "\\node" + a + ".exe"
+		fileName := root + "\\v" + v + "\\" + a + "-bit\\node.exe"
 
 		fmt.Printf("Downloading node.js version " + v + " (" + a + "-bit)... ")
 

--- a/src/nvm/web/web.go
+++ b/src/nvm/web/web.go
@@ -1,197 +1,198 @@
 package web
 
-import(
-  "fmt"
-  "net/http"
-  "net/url"
-  "os"
-  "io"
-  "io/ioutil"
-  "strings"
-  "strconv"
-  "../arch"
-  "../file"
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"../arch"
+	"../file"
 )
 
 var client = &http.Client{}
 var nodeBaseAddress = "https://nodejs.org/dist/"
 var npmBaseAddress = "https://github.com/npm/npm/archive/"
 
-func SetProxy(p string){
-  if p != "" && p != "none" {
-    proxyUrl, _ := url.Parse(p)
-    client = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)}}
-  } else {
-    client = &http.Client{}
-  }
+func SetProxy(p string) {
+	if p != "" && p != "none" {
+		proxyUrl, _ := url.Parse(p)
+		client = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)}}
+	} else {
+		client = &http.Client{}
+	}
 }
 
-func SetMirrors(node_mirror string, npm_mirror string){
-  if node_mirror != "" && node_mirror != "none"{
-    nodeBaseAddress = node_mirror;
-    if strings.ToLower(nodeBaseAddress[0:4]) != "http" {
-      nodeBaseAddress = "http://"+nodeBaseAddress
-    }
-  }
-  if npm_mirror != "" && npm_mirror != "none"{
-    npmBaseAddress = npm_mirror;
-    if strings.ToLower(npmBaseAddress[0:4]) != "http" {
-      npmBaseAddress = "http://"+npmBaseAddress
-    }
-  }
+func SetMirrors(node_mirror string, npm_mirror string) {
+	if node_mirror != "" && node_mirror != "none" {
+		nodeBaseAddress = node_mirror
+		if strings.ToLower(nodeBaseAddress[0:4]) != "http" {
+			nodeBaseAddress = "http://" + nodeBaseAddress
+		}
+	}
+	if npm_mirror != "" && npm_mirror != "none" {
+		npmBaseAddress = npm_mirror
+		if strings.ToLower(npmBaseAddress[0:4]) != "http" {
+			npmBaseAddress = "http://" + npmBaseAddress
+		}
+	}
 }
 
-func GetFullNodeUrl(path string) string{
-  return nodeBaseAddress+ path;
+func GetFullNodeUrl(path string) string {
+	return nodeBaseAddress + path
 }
 
-func  GetFullNpmUrl(path string) string{
-  return npmBaseAddress + path;
+func GetFullNpmUrl(path string) string {
+	return npmBaseAddress + path
 }
 
 func Download(url string, target string) bool {
 
-  output, err := os.Create(target)
-  if err != nil {
-    fmt.Println("Error while creating", target, "-", err)
-  }
-  defer output.Close()
+	output, err := os.Create(target)
+	if err != nil {
+		fmt.Println("Error while creating", target, "-", err)
+	}
+	defer output.Close()
 
-  response, err := client.Get(url)
-  if err != nil {
-    fmt.Println("Error while downloading", url, "-", err)
-  }
-  defer response.Body.Close()
+	response, err := client.Get(url)
+	if err != nil {
+		fmt.Println("Error while downloading", url, "-", err)
+	}
+	defer response.Body.Close()
 
-  _, err = io.Copy(output, response.Body)
-  if err != nil {
-    fmt.Println("Error while downloading", url, "-", err)
-  }
+	_, err = io.Copy(output, response.Body)
+	if err != nil {
+		fmt.Println("Error while downloading", url, "-", err)
+	}
 
-  if response.Status[0:3] != "200" {
-    fmt.Println("Download failed. Rolling Back.")
-    err := os.Remove(target)
-    if err != nil {
-      fmt.Println("Rollback failed.",err)
-    }
-    return false
-  }
+	if response.Status[0:3] != "200" {
+		fmt.Println("Download failed. Rolling Back.")
+		err := os.Remove(target)
+		if err != nil {
+			fmt.Println("Rollback failed.", err)
+		}
+		return false
+	}
 
-  return true
+	return true
 }
 
 func GetNodeJS(root string, v string, a string) bool {
 
-  a = arch.Validate(a)
+	a = arch.Validate(a)
 
-  vpre := ""
-  vers := strings.Fields(strings.Replace(v,"."," ",-1))
-  main, _ := strconv.ParseInt(vers[0],0,0)
+	vpre := ""
+	vers := strings.Fields(strings.Replace(v, ".", " ", -1))
+	main, _ := strconv.ParseInt(vers[0], 0, 0)
 
-  if a == "32" {
-    if main > 0 {
-      vpre = "win-x86/"
-    } else {
-      vpre = ""
-    }
-  } else if a == "64" {
-    if main > 0 {
-      vpre = "win-x64/"
-    } else {
-      vpre = "x64/"
-    }
-  }
-  
-  url := getNodeUrl ( v, vpre );
+	if a == "32" {
+		if main > 0 {
+			vpre = "win-x86/"
+		} else {
+			vpre = ""
+		}
+	} else if a == "64" {
+		if main > 0 {
+			vpre = "win-x64/"
+		} else {
+			vpre = "x64/"
+		}
+	}
 
-  if url == "" {
-    //No url should mean this version/arch isn't available
-    fmt.Println("Node.js v"+v+" " + a + "bit isn't available right now.")
-  } else {
-   fileName := root+"\\v"+v+"\\node"+a+".exe"
+	url := getNodeUrl(v, vpre)
 
-    fmt.Printf("Downloading node.js version "+v+" ("+a+"-bit)... ")
+	if url == "" {
+		//No url should mean this version/arch isn't available
+		fmt.Println("Node.js v" + v + " " + a + "bit isn't available right now.")
+	} else {
+		fileName := root + "\\v" + v + "\\node" + a + ".exe"
 
-    if Download(url,fileName) {
-      fmt.Printf("Complete\n")
-      return true
-    } else {
-      return false
-    }
-  }
-  return false
+		fmt.Printf("Downloading node.js version " + v + " (" + a + "-bit)... ")
+
+		if Download(url, fileName) {
+			fmt.Printf("Complete\n")
+			return true
+		} else {
+			return false
+		}
+	}
+	return false
 
 }
 
 func GetNpm(root string, v string) bool {
-  //url := "https://github.com/npm/npm/archive/v"+v+".zip"
-  url := GetFullNpmUrl("v"+v+".zip")
-  // temp directory to download the .zip file
-  tempDir := root+"\\temp"
+	//url := "https://github.com/npm/npm/archive/v"+v+".zip"
+	url := GetFullNpmUrl("v" + v + ".zip")
+	// temp directory to download the .zip file
+	tempDir := root + "\\temp"
 
-  // if the temp directory doesn't exist, create it
-  if (!file.Exists(tempDir)) {
-    fmt.Println("Creating "+tempDir+"\n")
-    err := os.Mkdir(tempDir, os.ModePerm)
-    if err != nil {
-      fmt.Println(err)
-      os.Exit(1)
-    }
-  }
-  fileName := tempDir+"\\"+"npm-v"+v+".zip"
+	// if the temp directory doesn't exist, create it
+	if !file.Exists(tempDir) {
+		fmt.Println("Creating " + tempDir + "\n")
+		err := os.Mkdir(tempDir, os.ModePerm)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+	fileName := tempDir + "\\" + "npm-v" + v + ".zip"
 
-  fmt.Printf("Downloading npm version "+v+"... ")
-  if Download(url,fileName) {
-    fmt.Printf("Complete\n")
-    return true
-  } else {
-    return false
-  }
+	fmt.Printf("Downloading npm version " + v + "... ")
+	if Download(url, fileName) {
+		fmt.Printf("Complete\n")
+		return true
+	} else {
+		return false
+	}
 }
 
 func GetRemoteTextFile(url string) string {
-  response, httperr := client.Get(url)
-  if httperr != nil {
-    fmt.Println("\nCould not retrieve "+url+".\n\n")
-    fmt.Printf("%s", httperr)
-    os.Exit(1)
-  } else {
-    defer response.Body.Close()
-    contents, readerr := ioutil.ReadAll(response.Body)
-    if readerr != nil {
-      fmt.Printf("%s", readerr)
-      os.Exit(1)
-    }
-    return string(contents)
-  }
-  os.Exit(1)
-  return ""
+	response, httperr := client.Get(url)
+	if httperr != nil {
+		fmt.Println("\nCould not retrieve " + url + ".\n\n")
+		fmt.Printf("%s", httperr)
+		os.Exit(1)
+	} else {
+		defer response.Body.Close()
+		contents, readerr := ioutil.ReadAll(response.Body)
+		if readerr != nil {
+			fmt.Printf("%s", readerr)
+			os.Exit(1)
+		}
+		return string(contents)
+	}
+	os.Exit(1)
+	return ""
 }
 
 func IsNode64bitAvailable(v string) bool {
-  if v == "latest" {
-    return true
-  }
+	if v == "latest" {
+		return true
+	}
 
-  // Anything below version 8 doesn't have a 64 bit version
-  vers := strings.Fields(strings.Replace(v,"."," ",-1))
-  main, _ := strconv.ParseInt(vers[0],0,0)
-  minor, _ := strconv.ParseInt(vers[1],0,0)
-  if main == 0 && minor < 8 {
-    return false
-  }
+	// Anything below version 8 doesn't have a 64 bit version
+	vers := strings.Fields(strings.Replace(v, ".", " ", -1))
+	main, _ := strconv.ParseInt(vers[0], 0, 0)
+	minor, _ := strconv.ParseInt(vers[1], 0, 0)
+	if main == 0 && minor < 8 {
+		return false
+	}
 
-  // TODO: fixme. Assume a 64 bit version exists
-  return true
+	// TODO: fixme. Assume a 64 bit version exists
+	return true
 }
 
-func getNodeUrl (v string,  vpre string) string {
-  //url := "http://nodejs.org/dist/v"+v+"/" + vpre + "/node.exe"
-  url := GetFullNodeUrl("v"+v+"/" + vpre + "/node.exe")
-  // Check online to see if a 64 bit version exists
-  _, err := client.Head( url )
-  if err != nil {
-    return ""
-  }
-  return url;
+func getNodeUrl(v string, vpre string) string {
+	//url := "http://nodejs.org/dist/v"+v+"/" + vpre + "/node.exe"
+	url := GetFullNodeUrl("v" + v + "/" + vpre + "/node.exe")
+	// Check online to see if a 64 bit version exists
+	_, err := client.Head(url)
+	if err != nil {
+		return ""
+	}
+	return url
 }


### PR DESCRIPTION
I've had a go at fixing issue #208. It seemed most sensible to create separate 32-bit and 64-bit directories. I've tried to make it backwards compatible, so existing installations will continue to work as-is, only newly installed node versions will get the new layout.

The delta to master looks massive (and unreadable!) at the minute because this includes all the go fmt changes from the previous pr.