### PR TITLE
Fix build issue.Fix node_mirror, npm_mirror not work issue.Add cleanup work when download is interrupted by user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ NVM for Windows is a command line tool. Simply type `nvm` in the console for hel
 - `nvm use <version> [arch]`: Switch to use the specified version. Optionally specify 32/64bit architecture. `nvm use <arch>` will continue using the selected version, but switch to 32/64 bit mode based on the value supplied to `<arch>`.
 - `nvm root <path>`: Set the directory where nvm should store different versions of node.js. If `<path>` is not set, the current root will be displayed.
 - `nvm version`: Displays the current running version of NVM for Windows.
+- `nvm node_mirror <node_mirror_url>`: Set the node mirror.People in China can use *https://npm.taobao.org/mirrors/node/*
+- `nvm npm_mirror <npm_mirror_url>`: Set the npm mirror.People in China can use *https://npm.taobao.org/mirrors/npm/*
 
 ### Gotcha!
 

--- a/nvm.iss
+++ b/nvm.iss
@@ -6,7 +6,7 @@
 #define MyAppURL "http://github.com/coreybutler/nvm"
 #define MyAppExeName "nvm.exe"
 #define MyIcon "bin\nodejs.ico"
-#define ProjectRoot "C:\Users\Corey\Documents\workspace\nvm-windows"
+#define ProjectRoot "."
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -108,8 +108,20 @@ func main() {
         saveSettings()
       }
     case "update": update()
+    case "node_mirror": setNodeMirror(detail)
+    case "npm_mirror": setNpmMirror(detail)
     default: help()
   }
+}
+
+func setNodeMirror(detail string) {
+	env.node_mirror = detail
+	saveSettings()
+}
+
+func setNpmMirror(detail string) {
+	env.npm_mirror = detail
+	saveSettings()
 }
 
 func update() {
@@ -574,8 +586,8 @@ func updateRootDir(path string) {
 }
 
 func saveSettings() {
-  content := "root: "+strings.Trim(env.root," \n\r")+"\r\narch: "+strings.Trim(env.arch," \n\r")+"\r\nproxy: "+strings.Trim(env.proxy," \n\r")+"\r\noriginalpath: "+strings.Trim(env.originalpath," \n\r")+"\r\noriginalversion: "+strings.Trim(env.originalversion," \n\r")
-  content = content + "node_mirror: "+strings.Trim(env.node_mirror," \n\r")+ "npm_mirror: "+strings.Trim(env.npm_mirror," \n\r")
+	content := "root: " + strings.Trim(env.root, " \n\r") + "\r\narch: " + strings.Trim(env.arch, " \n\r") + "\r\nproxy: " + strings.Trim(env.proxy, " \n\r") + "\r\noriginalpath: " + strings.Trim(env.originalpath, " \n\r") + "\r\noriginalversion: " + strings.Trim(env.originalversion, " \n\r")
+	content = content + "\r\nnode_mirror: " + strings.Trim(env.node_mirror, " \n\r") + "\r\nnpm_mirror: " + strings.Trim(env.npm_mirror, " \n\r")
   ioutil.WriteFile(env.settings, []byte(content), 0644)
 }
 


### PR DESCRIPTION
Let me talk about this pull request from the beginning.

I live in China, therefore downloading directly from nodejs.org or GitHub is so slow which is frustrating.

I want to use a mirror to speed up downloading, but I found that neither *nvm node_mirror* nor *nvm npm_mirror* would work.Then I use *ctrl+c* to interrupt the download process and try again.But I found that nvm told me that the version is already installed.Then I digged into the nvm directory and found there was a folder of the version which I interrupt.

So I  fix node_mirror, npm_mirror not work issue and add cleanup work when download is interrupted by user.
