### PR TITLE
Make sure file handle to 'node.exe' is closed after scanning for bytes

### DIFF
--- a/src/nvm/arch/arch.go
+++ b/src/nvm/arch/arch.go
@@ -22,6 +22,9 @@ func SearchBytesInFile( path string, match string, limit int) bool {
     return false;
   }
 
+  // Close file upon return
+  defer file.Close()
+
   // Allocate 1 byte array to perform the match
   bit := make([]byte, 1);
   j := 0


### PR DESCRIPTION
Fixes #252 for me ("defer" avoids file.Close() for each return, but you'll probably know that...)
