### PR TITLE
Auto choose highest version: #255

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ bin/nvm/*
 
 !.gitignore
 
+# Gogland Easy Mode
+.idea/

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -343,8 +343,13 @@ func use(version string, cpuarch string) {
   }
 
   if version == "auto" {
-    fmt.Println("Trying to auto match version...")
-    useLib.AutoUse(node.GetInstalled(env.root))
+    v, err := useLib.AutoUse(node.GetInstalled(env.root))
+    if err != nil {
+      fmt.Println("\nCould not auto find version, got:")
+      fmt.Println(err)
+      return
+    }
+    version = v
   }
 
   cpuarch = arch.Validate(cpuarch)

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -12,6 +12,7 @@ import (
   "./nvm/arch"
   "./nvm/file"
   "./nvm/node"
+  useLib "./nvm/use"
   "github.com/olekukonko/tablewriter"
 )
 
@@ -339,6 +340,11 @@ func use(version string, cpuarch string) {
     cpuarch = version
     v, _ := node.GetCurrentVersion()
     version = v
+  }
+
+  if version == "auto" {
+    fmt.Println("Trying to auto match version...")
+    useLib.AutoUse(node.GetInstalled(env.root))
   }
 
   cpuarch = arch.Validate(cpuarch)

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -345,7 +345,7 @@ func use(version string, cpuarch string) {
   if version == "auto" {
     v, err := useLib.AutoUse(node.GetInstalled(env.root))
     if err != nil {
-      fmt.Println("\nCould not auto find version, got:")
+      fmt.Println("\nCould not auto complete version, error received:")
       fmt.Println(err)
       return
     }

--- a/src/nvm/use/package.go
+++ b/src/nvm/use/package.go
@@ -1,0 +1,48 @@
+package use
+
+import (
+  "io/ioutil"
+  "errors"
+  "encoding/json"
+)
+
+type PackageJson struct {
+  Engines struct {
+    Node string `json:"node"`
+  } `json:"engines"`
+}
+
+func openPackage() ([]byte, error) {
+  file, e := ioutil.ReadFile("./package.json")
+  if e != nil {
+    return nil, errors.New("Error with package.json file present in this directory!")
+  }
+  return file, nil
+}
+
+func parsePackageFile(file []byte) (string, error) {
+  var packageData PackageJson
+  err := json.Unmarshal(file, &packageData)
+
+  if err != nil {
+    return "", err
+  }
+
+  if packageData.Engines.Node == "" {
+    return "", errors.New("Missing node version")
+  }
+
+  return packageData.Engines.Node, nil
+}
+
+func tryPackage() (string, error) {
+  packageFile, e := openPackage()
+  if e != nil {
+    return "", e
+  }
+  version, e := parsePackageFile(packageFile)
+  if e != nil {
+    return "", e
+  }
+  return version, nil
+}

--- a/src/nvm/use/semverUtil.go
+++ b/src/nvm/use/semverUtil.go
@@ -29,12 +29,12 @@ func stringToVersion(versions []string) ([]semver.Version) {
   return results
 }
 
-func getMinimumVersion(semVersions []semver.Version, semRange semver.Range) (semver.Version, error) {
+func getMaxVersion(sortedSemVersions []semver.Version, semRange semver.Range) (semver.Version, error) {
   var valid semver.Version
 
-  for _, value := range semVersions {
-    if semRange(value) {
-      return value, nil
+  for i := semver.Versions.Len(sortedSemVersions) - 1; i >= 0; i-- {
+    if semRange(sortedSemVersions[i]) {
+      return sortedSemVersions[i], nil
     }
   }
 

--- a/src/nvm/use/semverUtil.go
+++ b/src/nvm/use/semverUtil.go
@@ -1,0 +1,42 @@
+package use
+
+import (
+  "github.com/blang/semver"
+  "errors"
+)
+
+func popV(input string) string {
+  firstLetter := string(input[0])
+
+  if firstLetter == "V" || firstLetter == "v" {
+    input = input[1:len(input)]
+  }
+
+  return input
+}
+
+func stringToVersion(versions []string) ([]semver.Version) {
+  var results semver.Versions
+
+  for _, value := range versions {
+    value = popV(value)
+    ver, e := semver.Parse(value)
+    if e == nil {
+      results = append(results, ver)
+    }
+  }
+
+  return results
+}
+
+func getMinimumVersion(semVersions []semver.Version, semRange semver.Range) (semver.Version, error) {
+  var valid semver.Version
+
+  for _, value := range semVersions {
+    if semRange(value) {
+      return value, nil
+    }
+  }
+
+  return valid, errors.New("No version matched range specified.")
+}

--- a/src/nvm/use/use.go
+++ b/src/nvm/use/use.go
@@ -27,13 +27,14 @@ func packageJsonMatch(available semver.Versions) (string, error) {
     return "", nil
   }
 
-  minimum, err := getMinimumVersion(available, semRange)
+  minimum, err := getMaxVersion(available, semRange)
 
   return minimum.String(), err
 }
 
 func AutoUse(available []string) (string, error) {
   availableVersions := stringToVersion(available)
+  semver.Sort(availableVersions)
   version, e := packageJsonMatch(availableVersions)
 
   if e != nil {

--- a/src/nvm/use/use.go
+++ b/src/nvm/use/use.go
@@ -16,8 +16,7 @@ func packageJsonMatch(available semver.Versions) (string, error) {
   fmt.Println("\nRange Specified: ", engineRangeRaw)
 
   if engineRangeRaw == "*" {
-    fmt.Println("Wildcard Activated. This needs to be written!")
-    return "", nil
+    return available[semver.Versions.Len(available) - 1].String(), nil
   }
 
   semRange, e := semver.ParseRange(engineRangeRaw)

--- a/src/nvm/use/use.go
+++ b/src/nvm/use/use.go
@@ -2,21 +2,43 @@ package use
 
 import (
   "fmt"
-  "sort"
+  "github.com/blang/semver"
 )
 
-func readVersion() {
-  version, e := tryPackage()
+func packageJsonMatch(available semver.Versions) (string, error) {
+  engineRangeRaw, e := tryPackage()
 
   if e != nil {
-    fmt.Println(e)
+    // TODO: Error Handling
+    return "", e
   }
 
-  fmt.Println(version)
+  fmt.Println("\nRange Specified: ", engineRangeRaw)
+
+  if engineRangeRaw == "*" {
+    fmt.Println("Wildcard Activated. This needs to be written!")
+    return "", nil
+  }
+
+  semRange, e := semver.ParseRange(engineRangeRaw)
+
+  if e != nil {
+    // TODO: Error Handling
+    return "", nil
+  }
+
+  minimum, err := getMinimumVersion(available, semRange)
+
+  return minimum.String(), err
 }
 
 func AutoUse(available []string) (string, error) {
-  sort.Strings(available)
-  readVersion()
-  return "", nil
+  availableVersions := stringToVersion(available)
+  version, e := packageJsonMatch(availableVersions)
+
+  if e != nil {
+    return "", e
+  }
+
+  return version, nil
 }

--- a/src/nvm/use/use.go
+++ b/src/nvm/use/use.go
@@ -22,8 +22,7 @@ func packageJsonMatch(available semver.Versions) (string, error) {
   semRange, e := semver.ParseRange(engineRangeRaw)
 
   if e != nil {
-    // TODO: Error Handling
-    return "", nil
+    return "", e
   }
 
   minimum, err := getMaxVersion(available, semRange)

--- a/src/nvm/use/use.go
+++ b/src/nvm/use/use.go
@@ -1,0 +1,22 @@
+package use
+
+import (
+  "fmt"
+  "sort"
+)
+
+func readVersion() {
+  version, e := tryPackage()
+
+  if e != nil {
+    fmt.Println(e)
+  }
+
+  fmt.Println(version)
+}
+
+func AutoUse(available []string) (string, error) {
+  sort.Strings(available)
+  readVersion()
+  return "", nil
+}


### PR DESCRIPTION
Hi there,

This PR hopefully chooses the highest version in your `package.json` file, if you use `nvm use auto`, as per issue #255 

Is there anything I need to add? IE: function comments? I wasn't too sure what you would like in your repo, in terms of style guide.

So far, using [blang/semver](https://github.com/blang/semver) heavily so I don't have to rewrite a lot of the semver functions.

The functions it can do include:
  - auto choose highest version within given semver range
  - auto choose highest version installed, given wildcard `"*"`

Where can I improve?

Thank you,
Byron