### PR TITLE
closes file in SearchBytesInFile() to correct issues #252 #253

### DIFF
--- a/src/nvm/arch/arch.go
+++ b/src/nvm/arch/arch.go
@@ -38,6 +38,9 @@ func SearchBytesInFile( path string, match string, limit int) bool {
       }
     }
   }
+  if err == nil {
+    file.Close()
+  }
   return false;
 }
 


### PR DESCRIPTION
close file if it has been opened without error. Fixes issues #252 and #253.