### PR TITLE
Make Node versions consistent with nvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Make sure you use the same installation and symlink folder. If you originally in
 NVM for Windows is a command line tool. Simply type `nvm` in the console for help. The basic commands are:
 
 - `nvm arch [32|64]`: Show if node is running in 32 or 64 bit mode. Specify 32 or 64 to override the default architecture.
-- `nvm install <version> [arch]`: The version can be a node.js version or "latest" for the latest stable version. Optionally specify whether to install the 32 or 64 bit version (defaults to system arch). Set `[arch]` to "all" to install 32 AND 64 bit versions.
+- `nvm install <version> [arch]`: The version can be a node.js version or "node" for the latest stable version. Optionally specify whether to install the 32 or 64 bit version (defaults to system arch). Set `[arch]` to "all" to install 32 AND 64 bit versions.
 - `nvm list [available]`: List the node.js installations. Type `available` at the end to show a list of versions available for download.
 - `nvm on`: Enable node.js version management.
 - `nvm off`: Disable node.js version management (does not uninstall anything).
@@ -125,7 +125,7 @@ NVM for Windows comes with an installer, courtesy of a byproduct of my work on [
 
 Overall, this project brings together some ideas, a few battle-hardened pieces of other modules, and support for newer versions of node.
 
-NVM for Windows recognizes the "latest" versions using a [list](https://nodejs.org/download/release/index.json) provided by the Node project. Version 1.1.1+ use this list. Before this list existed, I was scraping releases and serving it as a standalone [data feed](https://github.com/coreybutler/nodedistro). This list was used in versions 1.1.0 and prior, but is now deprecated.
+NVM for Windows recognizes the latest versions using a [list](https://nodejs.org/download/release/index.json) provided by the Node project. Version 1.1.1+ use this list. Before this list existed, I was scraping releases and serving it as a standalone [data feed](https://github.com/coreybutler/nodedistro). This list was used in versions 1.1.0 and prior, but is now deprecated.
 
 ## Motivation
 

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -195,7 +195,7 @@ func install(version string, cpuarch string) {
   }
 
   // If user specifies "latest" version, find out what version is
-  if version == "latest" {
+  if (version == "latest" || version == "stable") {
     url := web.GetFullNodeUrl("latest/SHASUMS256.txt");
     content := web.GetRemoteTextFile(url)
     re := regexp.MustCompile("node-v(.+)+msi")

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -194,8 +194,8 @@ func install(version string, cpuarch string) {
     cpuarch = arch.Validate(cpuarch)
   }
 
-  // If user specifies "latest" version, find out what version is
-  if (version == "latest" || version == "stable") {
+  // If user specifies "node" (or "latest") version, find out what version is
+  if (version == "latest" || version == "node") {
     url := web.GetFullNodeUrl("latest/SHASUMS256.txt");
     content := web.GetRemoteTextFile(url)
     re := regexp.MustCompile("node-v(.+)+msi")
@@ -556,7 +556,7 @@ func help() {
   fmt.Println("\nUsage:")
   fmt.Println(" ")
   fmt.Println("  nvm arch                     : Show if node is running in 32 or 64 bit mode.")
-  fmt.Println("  nvm install <version> [arch] : The version can be a node.js version or \"latest\" for the latest stable version.")
+  fmt.Println("  nvm install <version> [arch] : The version can be a node.js version or \"node\" for the latest stable version.")
   fmt.Println("                                 Optionally specify whether to install the 32 or 64 bit version (defaults to system arch).")
   fmt.Println("                                 Set [arch] to \"all\" to install 32 AND 64 bit versions.")
   fmt.Println("                                 Add --insecure to the end of this command to bypass SSL validation of the remote download server.")

--- a/src/nvm/web/web.go
+++ b/src/nvm/web/web.go
@@ -188,7 +188,7 @@ func GetRemoteTextFile(url string) string {
 }
 
 func IsNode64bitAvailable(v string) bool {
-  if v == "latest" {
+  if (v == "latest" || v == "stable") {
     return true
   }
 

--- a/src/nvm/web/web.go
+++ b/src/nvm/web/web.go
@@ -188,7 +188,7 @@ func GetRemoteTextFile(url string) string {
 }
 
 func IsNode64bitAvailable(v string) bool {
-  if (v == "latest" || v == "stable") {
+  if (v == "latest" || v == "node") {
     return true
   }
 


### PR DESCRIPTION
[nvm](https://github.com/creationix/nvm#usage) uses `node` and `stable` to denote the latest version, though the latter is deprecated.

(Note that I was unable to build `nvm-windows` on OSX due to issues finding `settings.txt`, so this PR has not been _actually tested_.)