### PR TITLE
`nvm install` and `nvm use` resolve to latest versions Resolves #214

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -367,7 +367,40 @@ func cleanVersion(version string) string {
     }
   }
 
-  return matched
+  return strings.TrimLeft(matched, "v")
+}
+
+func cleanVersionInstalled(version string) string {
+  re := regexp.MustCompile("\\d+\\.\\d+\\.\\d+")
+  matched := re.FindString(version)
+
+  if len(matched) == 0 {
+    versions := node.GetInstalled(env.root)
+
+    sem := regexp.MustCompile("(\\d+)")
+    smVersion :=  sem.FindAllString(version, 3)
+    //If given major version only
+    if len(smVersion) == 1 {
+      for i := 0; i < len(versions); i++ {
+        result := sem.FindAllString(versions[i], 3)
+        if smVersion[0] == result[0] {
+          matched = versions[i]
+          break
+        }
+      }
+      //If given major-minor version
+    } else {
+      for i := 0; i < len(versions); i++ {
+        result := sem.FindAllString(versions[i], 3)
+        if smVersion[0] == result[0] && smVersion[1] == result[1] {
+          matched = versions[i]
+          break
+        }
+      }
+    }
+  }
+
+  return strings.TrimLeft(matched, "v")
 }
 
 func use(version string, cpuarch string) {
@@ -379,7 +412,7 @@ func use(version string, cpuarch string) {
 
   cpuarch = arch.Validate(cpuarch)
 
-  version = cleanVersion(version)
+  version = cleanVersionInstalled(version)
 
   // Make sure the version is installed. If not, warn.
   if !node.IsVersionInstalled(env.root,version,cpuarch) {

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -348,6 +348,7 @@ func cleanVersion(version string) string {
     smVersion :=  sem.FindAllString(version, 3)
     //If given major version only
     if len(smVersion) == 1 {
+      matched = version + ".0.0"
       for i := 0; i < len(versions); i++ {
         result := sem.FindAllString(versions[i].Version, 3)
         if smVersion[0] == result[0] {
@@ -357,6 +358,7 @@ func cleanVersion(version string) string {
       }
     //If given major-minor version
     } else {
+      matched = version + ".0"
       for i := 0; i < len(versions); i++ {
         result := sem.FindAllString(versions[i].Version, 3)
         if smVersion[0] == result[0] && smVersion[1] == result[1] {
@@ -381,6 +383,7 @@ func cleanVersionInstalled(version string) string {
     smVersion :=  sem.FindAllString(version, 3)
     //If given major version only
     if len(smVersion) == 1 {
+      matched = version + ".0.0"
       for i := 0; i < len(versions); i++ {
         result := sem.FindAllString(versions[i], 3)
         if smVersion[0] == result[0] {
@@ -390,6 +393,7 @@ func cleanVersionInstalled(version string) string {
       }
       //If given major-minor version
     } else {
+      matched = version + ".0"
       for i := 0; i < len(versions); i++ {
         result := sem.FindAllString(versions[i], 3)
         if smVersion[0] == result[0] && smVersion[1] == result[1] {

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -338,18 +338,33 @@ func uninstall(version string) {
 }
 
 func cleanVersion(version string) string {
-  re := regexp.MustCompile("\\d+.\\d+.\\d+")
+  re := regexp.MustCompile("\\d+\\.\\d+\\.\\d+")
   matched := re.FindString(version)
 
   if len(matched) == 0 {
-    re = regexp.MustCompile("\\d+.\\d+")
-    matched = re.FindString(version)
-    if len(matched) == 0 {
-      matched = version + ".0.0"
+    versions := web.GetNodeVersions()
+
+    sem := regexp.MustCompile("(\\d+)")
+    smVersion :=  sem.FindAllString(version, 3)
+    //If given major version only
+    if len(smVersion) == 1 {
+      for i := 0; i < len(versions); i++ {
+        result := sem.FindAllString(versions[i].Version, 3)
+        if smVersion[0] == result[0] {
+          matched = versions[i].Version
+          break
+        }
+      }
+    //If given major-minor version
     } else {
-      matched = matched + ".0"
+      for i := 0; i < len(versions); i++ {
+        result := sem.FindAllString(versions[i].Version, 3)
+        if smVersion[0] == result[0] && smVersion[1] == result[1] {
+          matched = versions[i].Version
+          break
+        }
+      }
     }
-    fmt.Println(matched)
   }
 
   return matched

--- a/src/nvm/web/web.go
+++ b/src/nvm/web/web.go
@@ -14,6 +14,7 @@ import(
   "strconv"
   "../arch"
   "../file"
+  "encoding/json"
 )
 
 var client = &http.Client{}
@@ -185,6 +186,24 @@ func GetRemoteTextFile(url string) string {
   }
   os.Exit(1)
   return ""
+}
+
+type Versions []struct {
+  Version string
+}
+
+func GetNodeVersions() Versions {
+  content := GetRemoteTextFile(GetFullNodeUrl("index.json"))
+  dec := json.NewDecoder(strings.NewReader(content))
+
+  var versions Versions
+  err := dec.Decode(&versions)
+  if err != nil {
+    fmt.Print(err)
+    os.Exit(1)
+  }
+
+  return versions
 }
 
 func IsNode64bitAvailable(v string) bool {


### PR DESCRIPTION
First time ever really using Go, so if anything could be optimized let me know.

`nvm install` will fetch the latest from node.org

- 6 -> 6.11.2 
- 6.10 -> 6.10.3
- 6.10.1 -> 6.10.1

`nvm use` will fetch the latest installed version

Given: 8.1.0, 8.7.0, 8.1.4

- 8 -> 8.7.0
- 8.1 -> 8.1.4
- 8.1.0 -> 8.1.0
- 6 -> 6.0.0 (resulting with a `is not installed` error)