### PR TITLE
nvm toggle #323 -  Toggle node version you use with "nvm toggle"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ NVM for Windows is a command line tool. Simply type `nvm` in the console for hel
 - `nvm uninstall <version>`: Uninstall a specific version.
 - `nvm use <version> [arch]`: Switch to use the specified version. Optionally specify 32/64bit architecture. `nvm use <arch>` will continue using the selected version, but switch to 32/64 bit mode based on the value supplied to `<arch>`. For information about using `use` in a specific directory (or using `.nvmrc`), please refer to [issue #16](https://github.com/coreybutler/nvm-windows/issues/16).
 - `nvm root <path>`: Set the directory where nvm should store different versions of node.js. If `<path>` is not set, the current root will be displayed.
+- `nvm toggle`: Switch to previously used version.
 - `nvm version`: Displays the current running version of NVM for Windows.
 - `nvm node_mirror <node_mirror_url>`: Set the node mirror.People in China can use *https://npm.taobao.org/mirrors/node/*
 - `nvm npm_mirror <npm_mirror_url>`: Set the npm mirror.People in China can use *https://npm.taobao.org/mirrors/npm/*

--- a/examples/settings.txt
+++ b/examples/settings.txt
@@ -2,3 +2,5 @@ root: C:\Users\Corey\AppData\Roaming\nvm
 path: C:\Program Files\nodejs
 arch: 64
 proxy: none
+pversion: 
+pcpuarch: 

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -435,9 +435,12 @@ func use(version string, cpuarch string) {
     }
     os.Rename(node64path, nodepath) // node64.exe -> node.exe
   }
-  env.pversion = pversion
-  env.pcpuarch = pcpuarch
-  saveSettings()
+  if(env.pversion != pversion || env.pcpuarch != pcpuarch ){
+     env.pversion = pversion
+     env.pcpuarch = pcpuarch
+     saveSettings()
+  }
+ 
   fmt.Println("Now using node v"+version+" ("+cpuarch+"-bit)")
 }
 


### PR DESCRIPTION
Approach: Settings.text is used to store previous version of node.
                Settings.text is first written with two new parameters namely "pversion" and "pcpuarch". 

Corner Condition: Firstly Settings.text will have empty value for above two parameters. Values change to previous version only on first use of "nvm use <version>" before that it gives error message of "You haven't used any version previously!!" and do nothing.