### PR TITLE
Added exponential backoff when moving npm installation directory

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -280,8 +280,7 @@ func install(version string, cpuarch string) {
         os.Rename(filepath.Join(tempNpmBin, "npx"), filepath.Join(env.root, "v"+version, "npx"))
         os.Rename(filepath.Join(tempNpmBin, "npx.cmd"), filepath.Join(env.root, "v"+version, "npx.cmd"))
       }
-
-      time.Sleep(10000*time.Millisecond)
+      
       err := os.Rename(filepath.Join(tempDir, "nvm-npm", "npm-"+npmv), filepath.Join(env.root, "v"+version, "node_modules", "npm"))
       if err != nil {
         // sometimes Windows can take some time to enable access to large amounts of files after unzip, use exponential backoff to wait until it is ready


### PR DESCRIPTION
Fixes issue when installing Node version: 8.9.1+

I found, to much frustration, that the npm installation folder was not being moved from nvm/temp/nvm-npm/{npm-version} to nvm/{node-version}/node_modules/npm. No matter how many times I retried, it just wasn't working.

Nothing in the source code seemed to be revealing anything obvious, so I decided to fork the repo and debug it manually using VS Code's Go plugin. Somehow, magically, when I stepped through the program line by line, the move went just fine without issues. This led me to believe that the problem was time-based.

Sure enough, when I added a ten-second delay before moving the directory, it worked just fine. It seems that (for my system anyway) Windows can take a long time to give access to large directories after being unzipped. For Node versions <8 this may not have been a problem because NPM's dependencies may have been smaller. But for recent versions this just won't cut it.

In my testing, it seemed that anywhere between 5 and 10 seconds is required before the move will succeed. I added an exponential backoff that will:
- First try right away
- If the first attempt fails, wait 1 second
- If the second attempt fails, wait 2 seconds
- ..., wait 4 seconds
- ..., wait 8 seconds
- ..., wait 16 seconds
- If it fails after waiting the total 31 seconds, then it will expose the error to the user because there is likely some other problem

I tested this several times and it has worked every time, so I am pretty confident in it.

This is my first time using Go, so I don't know if there is a better standard library API to implement this, but I gave it my best shot. Feel free to refactor it if you know of a better way.