### PR TITLE
Fix install.cmd

### DIFF
--- a/bin/install.cmd
+++ b/bin/install.cmd
@@ -1,7 +1,9 @@
 @echo off
 set /P NVM_PATH="Enter the absolute path where the zip file is extracted/copied to: "
-setx /M NVM_HOME "%NVM_PATH%"
-setx /M NVM_SYMLINK "C:\Program Files\nodejs"
+set NVM_HOME=%NVM_PATH%
+set NVM_SYMLINK=C:\Program Files\nodejs
+setx /M NVM_HOME "%NVM_HOME%"
+setx /M NVM_SYMLINK "%NVM_SYMLINK%"
 setx /M PATH "%PATH%;%NVM_HOME%;%NVM_SYMLINK%"
 
 if exist "%SYSTEMDRIVE%\Program Files (x86)\" (

--- a/bin/install.cmd
+++ b/bin/install.cmd
@@ -4,7 +4,10 @@ set NVM_HOME=%NVM_PATH%
 set NVM_SYMLINK=C:\Program Files\nodejs
 setx /M NVM_HOME "%NVM_HOME%"
 setx /M NVM_SYMLINK "%NVM_SYMLINK%"
-setx /M PATH "%PATH%;%NVM_HOME%;%NVM_SYMLINK%"
+
+for /f "skip=2 tokens=2,*" %%A in ('reg query "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" /v Path 2^>nul') do (
+  setx /M PATH "%%B;%%NVM_HOME%%;%%NVM_SYMLINK%%"
+)
 
 if exist "%SYSTEMDRIVE%\Program Files (x86)\" (
 set SYS_ARCH=64


### PR DESCRIPTION
The install.cmd doesn't work correctly.
- Environment variables (NVM_HOME and NVM_SYMLINK) are not set in current process
- Set system-environment PATH to system and user mixed environment PATH

Fixed by the following :
- Set environment variables for current process
- Avoid mixing user-environment PATH and system-environment PATH
