### PR TITLE
Fixes #252 - Need to manually remove folder on nvm uninstall

### DIFF
--- a/src/nvm/arch/arch.go
+++ b/src/nvm/arch/arch.go
@@ -34,10 +34,12 @@ func SearchBytesInFile( path string, match string, limit int) bool {
     if bit[0] == toMatch[j] {
       j++;
       if (j >= len(toMatch)) {
+        file.Close();
         return true;
       }
     }
   }
+  file.Close();
   return false;
 }
 


### PR DESCRIPTION
File handle when checking the architecture of the node executable was left open.