### PR TITLE
refactor: formatting codes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.go]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/nvm.go
+++ b/src/nvm.go
@@ -122,13 +122,13 @@ func main() {
 }
 
 func setNodeMirror(uri string) {
-	env.node_mirror = uri
-	saveSettings()
+  env.node_mirror = uri
+  saveSettings()
 }
 
 func setNpmMirror(uri string) {
-	env.npm_mirror = uri
-	saveSettings()
+  env.npm_mirror = uri
+  saveSettings()
 }
 
 func update() {
@@ -150,19 +150,19 @@ func CheckVersionExceedsLatest(version string) bool{
   content := web.GetRemoteTextFile(url)
   re := regexp.MustCompile("node-v(.+)+msi")
   reg := regexp.MustCompile("node-v|-x.+")
-	latest := reg.ReplaceAllString(re.FindString(content),"")
-	var vArr = strings.Split(version,".")
-	var lArr = strings.Split(latest, ".")
-	for index := range lArr {
-	lat,_ := strconv.Atoi(lArr[index])
-	ver,_ := strconv.Atoi(vArr[index])
+  latest := reg.ReplaceAllString(re.FindString(content),"")
+  var vArr = strings.Split(version,".")
+  var lArr = strings.Split(latest, ".")
+  for index := range lArr {
+  lat,_ := strconv.Atoi(lArr[index])
+  ver,_ := strconv.Atoi(vArr[index])
   //Should check for valid input (checking for conversion errors) but this tool is made to trust the user
-		if ver < lat {
+    if ver < lat {
       return false
-		} else if ver > lat {
+    } else if ver > lat {
       return true
     }
-	}
+  }
   return false
 }
 
@@ -214,8 +214,8 @@ func install(version string, cpuarch string) {
   }
 
   if CheckVersionExceedsLatest(version) {
-  	fmt.Println("Node.js v"+version+" is not yet released or available.")
-  	return
+    fmt.Println("Node.js v"+version+" is not yet released or available.")
+    return
   }
   if cpuarch == "64" && !web.IsNode64bitAvailable(version) {
     fmt.Println("Node.js v"+version+" is only available in 32-bit.")
@@ -373,12 +373,12 @@ func uninstall(version string) {
 }
 
 func findLatestSubVersion(version string) string {
-	url := web.GetFullNodeUrl("latest-v" + version + ".x" + "/SHASUMS256.txt")
-	content := web.GetRemoteTextFile(url)
-	re := regexp.MustCompile("node-v(.+)+msi")
-	reg := regexp.MustCompile("node-v|-x.+")
-	latest := reg.ReplaceAllString(re.FindString(content), "")
-	return latest
+  url := web.GetFullNodeUrl("latest-v" + version + ".x" + "/SHASUMS256.txt")
+  content := web.GetRemoteTextFile(url)
+  re := regexp.MustCompile("node-v(.+)+msi")
+  reg := regexp.MustCompile("node-v|-x.+")
+  latest := reg.ReplaceAllString(re.FindString(content), "")
+  return latest
 }
 
 func cleanVersion(version string) string {
@@ -614,7 +614,7 @@ func help() {
   fmt.Println("                                 Optionally specify whether to install the 32 or 64 bit version (defaults to system arch).")
   fmt.Println("                                 Set [arch] to \"all\" to install 32 AND 64 bit versions.")
   fmt.Println("                                 Add --insecure to the end of this command to bypass SSL validation of the remote download server.")
-    fmt.Println("  nvm list [available]         : List the node.js installations. Type \"available\" at the end to see what can be installed. Aliased as ls.")
+  fmt.Println("  nvm list [available]         : List the node.js installations. Type \"available\" at the end to see what can be installed. Aliased as ls.")
   fmt.Println("  nvm on                       : Enable node.js version management.")
   fmt.Println("  nvm off                      : Disable node.js version management.")
   fmt.Println("  nvm proxy [url]              : Set a proxy to use for downloads. Leave [url] blank to see the current proxy.")
@@ -652,8 +652,8 @@ func updateRootDir(path string) {
 }
 
 func saveSettings() {
-	content := "root: " + strings.Trim(env.root, " \n\r") + "\r\narch: " + strings.Trim(env.arch, " \n\r") + "\r\nproxy: " + strings.Trim(env.proxy, " \n\r") + "\r\noriginalpath: " + strings.Trim(env.originalpath, " \n\r") + "\r\noriginalversion: " + strings.Trim(env.originalversion, " \n\r")
-	content = content + "\r\nnode_mirror: " + strings.Trim(env.node_mirror, " \n\r") + "\r\nnpm_mirror: " + strings.Trim(env.npm_mirror, " \n\r")
+  content := "root: " + strings.Trim(env.root, " \n\r") + "\r\narch: " + strings.Trim(env.arch, " \n\r") + "\r\nproxy: " + strings.Trim(env.proxy, " \n\r") + "\r\noriginalpath: " + strings.Trim(env.originalpath, " \n\r") + "\r\noriginalversion: " + strings.Trim(env.originalversion, " \n\r")
+  content = content + "\r\nnode_mirror: " + strings.Trim(env.node_mirror, " \n\r") + "\r\nnpm_mirror: " + strings.Trim(env.npm_mirror, " \n\r")
   ioutil.WriteFile(env.settings, []byte(content), 0644)
 }
 

--- a/src/nvm/arch/arch.go
+++ b/src/nvm/arch/arch.go
@@ -15,7 +15,7 @@ func SearchBytesInFile( path string, match string, limit int) bool {
   if (err != nil) {
     return false;
   }
-  
+
   // Opening the file and checking if there is an arror
   file, err := os.Open(path)
   if err != nil {

--- a/src/nvm/node/node.go
+++ b/src/nvm/node/node.go
@@ -81,12 +81,12 @@ func IsVersionAvailable(v string) bool {
 }
 
 func reverseStringArray(str []string) []string {
-	for i := 0; i < len(str)/2; i++ {
-		j := len(str) - i - 1
-		str[i], str[j] = str[j], str[i]
-	}
+  for i := 0; i < len(str)/2; i++ {
+    j := len(str) - i - 1
+    str[i], str[j] = str[j], str[i]
+  }
 
-	return str
+  return str
 }
 
 func GetInstalled(root string) []string {

--- a/src/nvm/web/web.go
+++ b/src/nvm/web/web.go
@@ -8,8 +8,8 @@ import(
   "os/signal"
   "io"
   "io/ioutil"
-	"strings"
-	"syscall"
+  "strings"
+  "syscall"
   "crypto/tls"
   "strconv"
   "../arch"
@@ -67,23 +67,23 @@ func Download(url string, target string, version string) bool {
   }
   defer response.Body.Close()
   c := make(chan os.Signal, 2)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-c
-		fmt.Println("Download interrupted.Rolling back...")
-		output.Close()
-		response.Body.Close()
-		var err error
-		if strings.Contains(target, "node") {
-			err = os.RemoveAll(os.Getenv("NVM_HOME") + "\\v" + version)
-		} else {
-			err = os.Remove(target)
-		}
-		if err != nil {
-			fmt.Println("Error while rolling back", err)
-		}
-		os.Exit(1)
-	}()
+  signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+  go func() {
+    <-c
+    fmt.Println("Download interrupted.Rolling back...")
+    output.Close()
+    response.Body.Close()
+    var err error
+    if strings.Contains(target, "node") {
+      err = os.RemoveAll(os.Getenv("NVM_HOME") + "\\v" + version)
+    } else {
+      err = os.Remove(target)
+    }
+    if err != nil {
+      fmt.Println("Error while rolling back", err)
+    }
+    os.Exit(1)
+  }()
   _, err = io.Copy(output, response.Body)
   if err != nil {
     fmt.Println("Error while downloading", url, "-", err)


### PR DESCRIPTION
I saw PR #355 has a big diff on `src\nvm.go`, then I noticed currently `src\nvm.go` is using CRLF end of line while other go files using LF, and found there are mixed-use of spaces and tabs indentation. So I create this pull request for formatting the go codes (changing `src\nvm.go` to use LF, and converting all tabs to spaces), and adding the [`editorconfig`](https://editorconfig.org/) file, no functionality changes.