### PR TITLE
executables should be binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text eol=lf
+*.exe binary
+*.dll binary
+*.e32 binary


### PR DESCRIPTION
add entries to .gitattributes to ensure executables are handled as binaries