### PR TITLE
os.Rename() Access is denied

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -292,7 +292,7 @@ func install(version string, cpuarch string) {
         // sometimes Windows can take some time to enable access to large amounts of files after unzip, use exponential backoff to wait until it is ready
         for _, i := range [5]int{1, 2, 4, 8, 16} {
           time.Sleep(time.Duration(i)*time.Second)
-          moveNpmErr = os.Rename(filepath.Join(tempDir, "nvm-npm", "npm-"+npmv), filepath.Join(env.root, "v"+version, "node_modules", "npm"))
+          moveNpmErr = os.Rename(npmSourcePath, filepath.Join(env.root, "v"+version, "node_modules", "npm"))
           if moveNpmErr == nil { break }
         }
       }


### PR DESCRIPTION
While performing the Rename operation, if an access is denied error occurs, then due to the filePath potentially being incorrect in later node versions, retries were not being attempted.