### PR TITLE
os.Rename() - "Access is denied" error when moving npm from temp folder is swallowed

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -292,17 +292,20 @@ func install(version string, cpuarch string) {
         // sometimes Windows can take some time to enable access to large amounts of files after unzip, use exponential backoff to wait until it is ready
         for _, i := range [5]int{1, 2, 4, 8, 16} {
           time.Sleep(time.Duration(i)*time.Second)
-          moveNpmErr = os.Rename(filepath.Join(tempDir, "nvm-npm", "npm-"+npmv), filepath.Join(env.root, "v"+version, "node_modules", "npm"))
+          moveNpmErr = os.Rename(npmSourcePath, filepath.Join(env.root, "v"+version, "node_modules", "npm"))
           if moveNpmErr == nil { break }
         }
+
       }
 
-      if err == nil {
+      if err == nil && moveNpmErr == nil {
         // Remove the temp directory
         // may consider keep the temp files here
         os.RemoveAll(tempDir)
 
         fmt.Println("\n\nInstallation complete. If you want to use this version, type\n\nnvm use "+version)
+      } else if moveNpmErr != nil {
+        fmt.Println("Error: Unable to move directory "+npmSourcePath+" to node_modules: "+moveNpmErr.Error())
       } else {
         fmt.Println("Error: Unable to install NPM: "+err.Error());
       }


### PR DESCRIPTION
nvm-windows currently fails silently if there's an access error when moving the npm folder from temp into the installed node version's modules folder with os.Rename(). The error happens for newer node versions due to an oversight in the npm folder path used in the retry block. The error is never caught and printed, so nvm-windows users may find that npm is not properly installed, despite the output looking completely normal.

This commit fixes the underlying issue, but also adds an error catch block that explains the issue to eventual debuggers.