### PR TITLE
Installer improvements when alt creds are required for elevation

### DIFF
--- a/bin/setuserenv.vbs
+++ b/bin/setuserenv.vbs
@@ -1,0 +1,11 @@
+Set WSHShell = CreateObject("WScript.Shell")
+userpath = WSHShell.RegRead("HKCU\Environment\Path")
+If InStr(userpath, "%NVM_HOME%") = False Then
+    userpath = userpath & ";%NVM_HOME%;"
+End If
+If InStr(userpath, "%NVM_SYMLINK%") = False Then
+    userpath = userpath & ";%NVM_SYMLNK%;"
+End If
+
+userpath = Replace(userpath, ";;", ";")
+WSHShell.RegWrite "HKCU\Environment\Path", userpath

--- a/bin/setuserenv.vbs
+++ b/bin/setuserenv.vbs
@@ -4,7 +4,7 @@ If InStr(userpath, "%NVM_HOME%") = False Then
     userpath = userpath & ";%NVM_HOME%;"
 End If
 If InStr(userpath, "%NVM_SYMLINK%") = False Then
-    userpath = userpath & ";%NVM_SYMLNK%;"
+    userpath = userpath & ";%NVM_SYMLINK%;"
 End If
 
 userpath = Replace(userpath, ";;", ";")

--- a/bin/unsetuserenv.vbs
+++ b/bin/unsetuserenv.vbs
@@ -1,0 +1,6 @@
+Set WSHShell = CreateObject("WScript.Shell")
+userpath = WSHShell.RegRead("HKCU\Environment\Path")
+userpath = Replace(userpath, "%NVM_HOME%", "")
+userpath = Replace(userpath, "%NVM_SYMLINK%", "")
+userpath = Replace(userpath, ";;", ";")
+WSHShell.RegWrite "HKCU\Environment\Path", userpath

--- a/nvm.iss
+++ b/nvm.iss
@@ -82,6 +82,7 @@ var
 procedure TakeControl(np: string; nv: string);
 var
   path: string;
+  ResultCode: integer;
 begin
   // Move the existing node.js installation directory to the nvm root & update the path
   RenameFile(np,ExpandConstant('{app}')+'\'+nv);
@@ -192,6 +193,7 @@ function InitializeUninstall(): Boolean;
 var
   path: string;
   nvm_symlink: string;
+  ResultCode: integer;
 begin
   SuppressibleMsgBox('Removing NVM for Windows will remove the nvm command and all versions of node.js, including global npm modules.', mbInformation, MB_OK, IDOK);
 

--- a/nvm.iss
+++ b/nvm.iss
@@ -96,7 +96,7 @@ begin
 
   RegWriteExpandStringValue(HKEY_LOCAL_MACHINE, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'Path', path);
 
-  ExecAsOriginalUser('wscript', 'setuserenv.vbs', ExpandConstant('{app}'), SW_SHOW, ewWaitUntilTerminated, ResultCode);
+  ExecAsOriginalUser('wscript', 'setuserenv.vbs', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
 
   nodeInUse := ExpandConstant('{app}')+'\'+nv;
 
@@ -221,7 +221,7 @@ begin
 
   RegWriteExpandStringValue(HKEY_LOCAL_MACHINE, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'Path', path);
 
-  ExecAsOriginalUser('wscript', 'unsetuserenv.vbs', ExpandConstant('{app}'), SW_SHOW, ewWaitUntilTerminated, ResultCode);
+  ExecAsOriginalUser('wscript', 'unsetuserenv.vbs', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
 
   Result := True;
 end;
@@ -256,7 +256,7 @@ begin
       StringChangeEx(path,';;',';',True);
       RegWriteExpandStringValue(HKEY_LOCAL_MACHINE, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'Path', path);
     end;
-    ExecAsOriginalUser('wscript', 'setuserenv.vbs', ExpandConstant('{app}'), SW_SHOW, ewWaitUntilTerminated, ResultCode);
+    ExecAsOriginalUser('wscript', 'setuserenv.vbs', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
   end;
 end;
 


### PR DESCRIPTION
When installing nvm-windows, if you supply alternate credentials to gain elevation, the installer will create the user environment variables under the user profile of the credentials you supplied rather then the user profile of the user who originally launched the installer. To get around this I made use of the ExecAsOriginalUser Inno Setup function. This function lets you shell execute under the original user. I was able to call REG.EXE to add %NVM_HOME% and %NVM_SYMLINK% but to handle the parsing/appending of the original path I had to create a VBScript and launch it with ExecAsOriginalUser. I actually created a setuserenv.vbs for the install and unsetuserenv.vbs for the uninstall.