### PR TITLE
Fix detection algorithm of major version in `nvm install`

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -192,7 +192,8 @@ func install(version string, cpuarch string) {
 
   // if the user specifies only the major version number then install the latest
   // version of the major version number
-  if len(version) == 1 {
+  designatedOnlyMajorVersion, _ := regexp.MatchString("^[1-9][0-9]*$", version)
+  if designatedOnlyMajorVersion {
     version = findLatestSubVersion(version)
   } else {
     version = cleanVersion(version)


### PR DESCRIPTION
I've been bothered by the problem `nvm install 12` installs the version 12.0.0, not 12.8.0.
I found `nvm install X` (`X` is an integer larger than 9) doesn't call the function `findLatestSubVersion` (`findLatestSubVersion("12")` returns `"12.8.0"`), but calls `cleanVersion` (`cleanVersion("12")` always returns `"12.0.0"`).