### PR TITLE
Support `nvm install lts`

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -181,13 +181,17 @@ func install(version string, cpuarch string) {
     cpuarch = arch.Validate(cpuarch)
   }
 
-  // If user specifies "latest" version, find out what version is
+  // If user specifies "latest" or "lts" (latest LTS) version, find out what version is
   if version == "latest" {
     url := web.GetFullNodeUrl("latest/SHASUMS256.txt");
     content := web.GetRemoteTextFile(url)
     re := regexp.MustCompile("node-v(.+)+msi")
     reg := regexp.MustCompile("node-v|-x.+")
     version = reg.ReplaceAllString(re.FindString(content),"")
+  } else if version == "lts" {
+    _, ltsList, _, _, _, _ := node.GetAvailable()
+    // ltsList has already been numerically sorted
+    version = ltsList[0]
   }
 
   // if the user specifies only the major version number then install the latest
@@ -576,7 +580,7 @@ func help() {
   fmt.Println("\nUsage:")
   fmt.Println(" ")
   fmt.Println("  nvm arch                     : Show if node is running in 32 or 64 bit mode.")
-  fmt.Println("  nvm install <version> [arch] : The version can be a node.js version or \"latest\" for the latest stable version.")
+  fmt.Println("  nvm install <version> [arch] : The version can be a node.js version, \"latest\" for the latest stable version, or \"lts\" for the latest LTS.")
   fmt.Println("                                 Optionally specify whether to install the 32 or 64 bit version (defaults to system arch).")
   fmt.Println("                                 Set [arch] to \"all\" to install 32 AND 64 bit versions.")
   fmt.Println("                                 Add --insecure to the end of this command to bypass SSL validation of the remote download server.")


### PR DESCRIPTION
It's required to add an option to install the latest LTS version because it's officially said to be recommended for most users.
I made it possible to do it by add `lts` label to `nvm install`.