### PR TITLE
Convert ambiguous date into standard format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Better yet, **click the "Sponsor" button** at the top of this screen. Patreon sp
 
 ## NOTICES
 
-(9/6/19) I am actively working on new Github actions to build releases. There are several great contributions in master (which contains the to-be-released 1.1.8 version), but I've always had to build these by hand.... and as many of you have noticed, my time has been extremely limited for quite awhile. The time consuming part is preparing the NSIS build, but once that is automated, it should be significantly easier for people to contribute changes _and actually see them released_.
+(2019-09-06) I am actively working on new Github actions to build releases. There are several great contributions in master (which contains the to-be-released 1.1.8 version), but I've always had to build these by hand.... and as many of you have noticed, my time has been extremely limited for quite awhile. The time consuming part is preparing the NSIS build, but once that is automated, it should be significantly easier for people to contribute changes _and actually see them released_.
 
 Older notices have moved to the [notices wiki entry](https://github.com/coreybutler/nvm-windows/wiki/Notices).
 


### PR DESCRIPTION
Sorry to be picky, but I got bitten by some ambiguous date format problems recently so...

The date I am converting (9/6/19) is Sep 6th if it is in US format and is June 9th for all other English speaking countries (I'm highlighting English countries only because this text is in English).  I determined that it is US format by looking at the date of the commit.

I suggest that stuff like this use [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format because it is unambiguous, it is popular amongst developers, it is getting wider adoption, and it is a great format!  Thanks.