### PR TITLE
Redundant file.Close(), already deferred

### DIFF
--- a/src/nvm/arch/arch.go
+++ b/src/nvm/arch/arch.go
@@ -42,7 +42,6 @@ func SearchBytesInFile( path string, match string, limit int) bool {
       }
     }
   }
-  file.Close();
   return false;
 }
 


### PR DESCRIPTION
There is already a deferred file.Close()