### PR TITLE
Do not elevate unless necessary

### DIFF
--- a/bin/elevate.cmd
+++ b/bin/elevate.cmd
@@ -1,5 +1,12 @@
 @setlocal
 @echo off
+
+:: Try without elevation, in case %NVM_SYMLINK% is a user-owned path and the 
+:: machine has Windows 10 Developer Mode enabled
+%*
+if %ERRORLEVEL% LSS 1 goto :EOF
+
+:: The command failed without elevation, try with elevation
 set CMD=%*
 set APP=%1
 start wscript //nologo "%~dpn0.vbs" %*


### PR DESCRIPTION
This changes `elevate.cmd` to first try to execute the requested command *without* elevation. If the command failed (i.e., `ERRORLEVEL` was non-zero), then retry the command with elevation.

Fixes #510