### PR TITLE
Fixes url to the complete list of nodejs downloads

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -538,7 +538,7 @@ func list(listtype string) {
     table.AppendBulk(data) // Add Bulk Data
     table.Render()
 
-    fmt.Println("\nThis is a partial list. For a complete list, visit https://nodejs.org/download/release")
+    fmt.Println("\nThis is a partial list. For a complete list, visit https://nodejs.org/download/releases")
   }
 }
 


### PR DESCRIPTION
Existing url gives a 404.  This fix replaces it with the correct url.