### PR TITLE
Fix major version check

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -192,7 +192,7 @@ func install(version string, cpuarch string) {
 
   // if the user specifies only the major version number then install the latest
   // version of the major version number
-  if len(version) == 1 {
+  if !strings.Contains(version, ".") {
     version = findLatestSubVersion(version)
   } else {
     version = cleanVersion(version)


### PR DESCRIPTION
There is existing functionality which is supposed to allow you to specify a major version e.g `nvm install 9` and have it install the latest v9. This was just checking the length of version is 1, which means `nvm install 10` installs `10.0.0`. I've changed this to check if the string contains no `.`, which (I think?) is a more reasonable approach which will work for future versions.