### PR TITLE
add support for nvm current command 

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -17,6 +17,7 @@ import (
   "./nvm/arch"
   "./nvm/file"
   "./nvm/node"
+  "github.com/blang/semver"
   "github.com/olekukonko/tablewriter"
 )
 
@@ -115,7 +116,16 @@ func main() {
         env.proxy = detail
         saveSettings()
       }
-
+    case "current":
+      inuse, _ := node.GetCurrentVersion()
+      v, _ := semver.Make(inuse)
+      err := v.Validate()
+      if err == nil {
+        fmt.Println("v" + inuse)
+      } else {
+        fmt.Println(inuse)
+      }
+  
     //case "update": update()
     case "node_mirror": setNodeMirror(detail)
     case "npm_mirror": setNpmMirror(detail)


### PR DESCRIPTION
add support for nvm current command as the linux nvm has that its missing in windows version.
certain terminal use it to detect the version of node like https://github.com/denysdovhan/spaceship-prompt