### PR TITLE
Suppress remove prompt and force delete

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -399,7 +399,7 @@ func use(version string, cpuarch string) {
   // Remove symlink if it already exists
   sym, _ := os.Stat(env.symlink)
   if sym != nil {
-    if !runElevated(fmt.Sprintf(`"%s" cmd /C rmdir "%s"`,
+    if !runElevated(fmt.Sprintf(`"%s" cmd /C rmdir /Q /S "%s"`,
       filepath.Join(env.root, "elevate.cmd"),
       filepath.Clean(env.symlink))) {
       return


### PR DESCRIPTION
Hello,

I do not know if this PR is helpful or not but I have been trying to use this on a Windows box recently and I have been getting some unpredictable results depending on how I have setup NodeJS prior to installing nvm-windows. 

Can you please explain: How NVM works when Node.js is already installed ?

For example I have tested in two scenarios. I have had some mixed results. Scenarios:

1. Install nvm-windows using official setup
By installing NVM on Windows  I have been able to install new Node.js versions. However with this approach I cannot see node being updated in my environemnt. I see the nodejs version in the NVM_HOME directory but not in my path.
2. Test nvm-windows directly using Go
I have tried to clone the source code and test it out locally. It all works fine but I am not able to see the "runElevated" call working all the time (see line 402 in nvm.go to be specific). The error I get is: exit status 145: The directory is not empty.

In my PR I have added the /S and /Q options to the the rmdir command. These options have helped me update my Windows environment (maybe there is another approach ?)

Again I do not know if this PR is helpful or not. If it is not helpful I would just like to know why these commands were not in the source code already. 

Is there a better approach to solving my problem ?

Thanks