### PR TITLE
Fix "&lt;user&gt;" -> "<user>" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ bleeding edge version without uninstalling the stable version of node, this util
 
 Uninstall any existing versions of Node.js before installing NVM for Windows (otherwise you'll have conflicting versions). Delete any existing Node.js installation directories (e.g., `%ProgramFiles%\nodejs`) that might remain. NVM's generated symlink will not overwrite an existing (even empty) installation directory.
 
-Backup any global `npmrc` config (e.g. `C:\Users\&lt;user&gt;\AppData\Roaming\npm\etc\npmrc`), or copy the settings to the user config `C:\Users\&lt;user&gt;\.npmrc`. Delete the existing npm install location (e.g. "C:\Users\\&lt;user&gt;\\AppData\Roaming\npm") to prevent global module conflicts. 
+Backup any global `npmrc` config (e.g. `C:\Users\<user>\AppData\Roaming\npm\etc\npmrc`), or copy the settings to the user config `C:\Users\<user>\.npmrc`. Delete the existing npm install location (e.g. "C:\Users\\&lt;user&gt;\\AppData\Roaming\npm") to prevent global module conflicts. 
 
 #### Install nvm-windows
 


### PR DESCRIPTION
Tags don't need to be escaped in Markdown inline code blocks. Or rather, they must not, since it will just print `&lt;` verbatim.