### PR TITLE
docs: update address of china mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ NVM for Windows is a command line tool. Simply type `nvm` in the console for hel
 - **`nvm use <version> [arch]`**: Switch to use the specified version. Optionally use `latest`, `lts`, or `newest`. `newest` is the latest _installed_ version. Optionally specify 32/64bit architecture. `nvm use <arch>` will continue using the selected version, but switch to 32/64 bit mode. For information about using `use` in a specific directory (or using `.nvmrc`), please refer to [issue #16](https://github.com/coreybutler/nvm-windows/issues/16).
 - **`nvm root <path>`**: Set the directory where nvm should store different versions of node.js. If `<path>` is not set, the current root will be displayed.
 - **`nvm version`: Displays the current running version of NVM for Windows.
-- **`nvm node_mirror <node_mirror_url>`**: Set the node mirror.People in China can use *https://npm.taobao.org/mirrors/node/*
-- **`nvm npm_mirror <npm_mirror_url>`**: Set the npm mirror.People in China can use *https://npm.taobao.org/mirrors/npm/*
+- **`nvm node_mirror <node_mirror_url>`**: Set the node mirror.People in China can use *https://npmmirror.com/mirrors/node/*
+- **`nvm npm_mirror <npm_mirror_url>`**: Set the npm mirror.People in China can use *https://npmmirror.com/mirrors/npm/*
 
 ### :warning: Gotcha!
 


### PR DESCRIPTION
Hi, thanks for the excellent work of nvm-windows.

For some regulatory reasons, we will offline `npm.taobao.org` at `2022.05.21`, and the new domain name is `npmmirror.com`.

Actually, the service that `npm.taobao.org` provided before has not changed:

```bash
nslookup npmmirror.com
Server:		30.30.30.30
Address:	30.30.30.30#53

Non-authoritative answer:
Name:	npmmirror.com
Address: 47.96.233.62

-----------

nslookup npm.taobao.org
Server:		30.30.30.30
Address:	30.30.30.30#53

Non-authoritative answer:
Name:	npm.taobao.org
Address: 114.55.80.225
```

We just re-registered a domain name and new SLB (Server Load Balancing) due to regulatory reasons.

Reference: https://zhuanlan.zhihu.com/p/430580607

