### PR TITLE
Fix missing DisplayVersion registry key for nvm.iss

### DIFF
--- a/nvm.iss
+++ b/nvm.iss
@@ -6,6 +6,7 @@
 #define MyAppURL "https://github.com/coreybutler/nvm-windows"
 #define MyAppExeName "nvm.exe"
 #define MyIcon "bin\nodejs.ico"
+#define MyAppId "40078385-F676-4C61-9A9C-F9028599D6D3"
 #define ProjectRoot "."
 
 [Setup]
@@ -15,7 +16,7 @@
 PrivilegesRequired=admin
 ; SignTool=MsSign $f
 ; SignedUninstaller=yes
-AppId=40078385-F676-4C61-9A9C-F9028599D6D3
+AppId={#MyAppId}
 AppName={#MyAppName}
 AppVersion={%AppVersion}
 AppVerName={#MyAppName} {%AppVersion}
@@ -260,6 +261,8 @@ begin
     RegWriteExpandStringValue(HKEY_LOCAL_MACHINE, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'NVM_SYMLINK', SymlinkPage.Values[0]);
     RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'NVM_HOME', ExpandConstant('{app}'));
     RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'NVM_SYMLINK', SymlinkPage.Values[0]);
+    
+    RegWriteStringValue(HKEY_LOCAL_MACHINE, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{#MyAppId}_is1', 'DisplayVersion', '{#MyAppVersion}');
 
     // Update system and user PATH if needed
     RegQueryStringValue(HKEY_LOCAL_MACHINE,


### PR DESCRIPTION
winget uses the **DisplayVersion** registry key to confirm whether the package should be updated:

![螢幕擷取畫面 2022-05-04 190542](https://user-images.githubusercontent.com/47501692/166669990-75419d17-41f6-44bb-bd3c-261f8a70a78f.png)

winget will display the correct version:

![螢幕擷取畫面 2022-05-04 190823](https://user-images.githubusercontent.com/47501692/166670338-d577eeb9-66aa-42b1-a082-a4faba2e88e1.png)

this avoids the problem of constant updates caused by **Unknown** versions.

refer to this [discussion](https://github.com/microsoft/winget-pkgs/issues/57635).
