### PR TITLE
passing in a unknown string as 'version' causes an error

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -206,8 +206,8 @@ func getVersion(version string, cpuarch string, localInstallsOnly ...bool) (stri
 		return "", cpuarch, errors.New("A version argument is required but missing.")
 	}
 
-	// If user specifies "latest" version, find out what version is
-	if version == "latest" {
+	// If user specifies "latest" version or a generic "node", find out what the latest version is
+	if version == "latest" || version == "node" {
 		version = getLatest()
 	}
 


### PR DESCRIPTION
nvm allows you to install the latest node with `nvm install node`. Current master has an out of bounds error when you try to install with `node` or use any random string for `version`.

Added a length check so will not have the error, and another check so it will print the appropriate error in that case. Also added the option to install latest with `nvm install node` like nvm does.