### PR TITLE
Fix install.cmd PATH bug

### DIFF
--- a/bin/install.cmd
+++ b/bin/install.cmd
@@ -5,7 +5,7 @@ set NVM_SYMLINK=C:\Program Files\nodejs
 setx /M NVM_HOME "%NVM_HOME%"
 setx /M NVM_SYMLINK "%NVM_SYMLINK%"
 
-(echo PATH=%PATH%) > %NVM_HOME%\PATH.txt
+echo PATH=%PATH% > %NVM_HOME%\PATH.txt
 
 for /f "skip=2 tokens=2,*" %%A in ('reg query "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" /v Path 2^>nul') do (
   setx /M PATH "%%B;%%NVM_HOME%%;%%NVM_SYMLINK%%"


### PR DESCRIPTION
If the PATH environment variable has parentheses, `(echo PATH=%PATH%)` will fail, but the parentheses don't seem to be needed.

This appears to be the same bug described in https://github.com/coreybutler/nvm-windows/issues/913.