### PR TITLE
Avoid panic after connection failure

### DIFF
--- a/src/web/web.go
+++ b/src/web/web.go
@@ -107,6 +107,7 @@ func Download(url string, target string, version string) bool {
 	response, err := client.Do(req)
 	if err != nil {
 		fmt.Println("Error while downloading", url, "-", err)
+		return false
 	}
 	defer response.Body.Close()
 	c := make(chan os.Signal, 2)


### PR DESCRIPTION
Return false after printing error information to avoid panic
fix #948