### PR TITLE
Fix nvm node upgrades | Update regex node.js version matching

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -597,7 +597,7 @@ func findLatestSubVersion(version string, localOnly ...bool) string {
 	url := web.GetFullNodeUrl("latest-v" + version + ".x" + "/SHASUMS256.txt")
 	content := web.GetRemoteTextFile(url)
 	re := regexp.MustCompile("node-v(.+)+msi")
-	reg := regexp.MustCompile("node-v|-x.+")
+	reg := regexp.MustCompile("node-v|-[xa].+")
 	latest := reg.ReplaceAllString(re.FindString(content), "")
 	return latest
 }
@@ -1009,7 +1009,7 @@ func checkVersionExceedsLatest(version string) bool {
 	url := web.GetFullNodeUrl("latest/SHASUMS256.txt")
 	content := web.GetRemoteTextFile(url)
 	re := regexp.MustCompile("node-v(.+)+msi")
-	reg := regexp.MustCompile("node-v|-x.+")
+	reg := regexp.MustCompile("node-v|-[xa].+")
 	latest := reg.ReplaceAllString(re.FindString(content), "")
 	var vArr = strings.Split(version, ".")
 	var lArr = strings.Split(latest, ".")
@@ -1054,7 +1054,7 @@ func getLatest() string {
 	url := web.GetFullNodeUrl("latest/SHASUMS256.txt")
 	content := web.GetRemoteTextFile(url)
 	re := regexp.MustCompile("node-v(.+)+msi")
-	reg := regexp.MustCompile("node-v|-x.+")
+	reg := regexp.MustCompile("node-v|-[xa].+")
 	return reg.ReplaceAllString(re.FindString(content), "")
 }
 


### PR DESCRIPTION
Fixes issues people are having with upgrading node. (e.g fixes: (https://github.com/coreybutler/nvm-windows/issues/955) (https://github.com/coreybutler/nvm-windows/issues/942) )

Node.js has added support for Windows ARM64 MSI files, which broke the regex version matching in nvm.go. It was only looking for msi files that had an "-x" in it (due to x86 and x64) and would use that -x as a reference point to retrieve the version number.

Went ahead and updated the regex so it can match x86, x64, and arm64 MSI's and now it can compare the versions properly. 
This resolves the `panic: runtime error: index out of range [3] with length 3` error. (which was happening because it would try to compare `[19,9,0]` with `[19,9,0-arm,msi]`