### PR TITLE
fix issue #932

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -1163,16 +1163,19 @@ func updateRootDir(path string) {
 }
 
 func elevatedRun(name string, arg ...string) (bool, error) {
-	ok, err := run("cmd", append([]string{"/C", name}, arg...)...)
+	ok, err := run("cmd", nil, append([]string{"/C", name}, arg...)...)
 	if err != nil {
-		ok, err = run(filepath.Join(env.root, "elevate.cmd"), append([]string{"cmd", "/C", name}, arg...)...)
+		ok, err = run("elevate.cmd", &env.root, append([]string{"cmd", "/C", name}, arg...)...)
 	}
 
 	return ok, err
 }
 
-func run(name string, arg ...string) (bool, error) {
+func run(name string, dir *string, arg ...string) (bool, error) {
 	c := exec.Command(name, arg...)
+	if dir != nil {
+		c.Dir = *dir
+	}
 	var stderr bytes.Buffer
 	c.Stderr = &stderr
 	err := c.Run()


### PR DESCRIPTION
fixes #932

Since `exec.Command(...)` has problems when the command is on a path with spaces, I replaced `filepath.Join(env.root, "elevate.cmd")` by setting the `Dir` parameter in type `Cmd` instead.