### PR TITLE
Use relative path

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -1352,7 +1352,7 @@ func updateRootDir(path string) {
 func elevatedRun(name string, arg ...string) (bool, error) {
 	ok, err := run("cmd", nil, append([]string{"/C", name}, arg...)...)
 	if err != nil {
-		ok, err = run("elevate.cmd", &env.root, append([]string{"cmd", "/C", name}, arg...)...)
+		ok, err = run(".\\elevate.cmd", &env.root, append([]string{"cmd", "/C", name}, arg...)...)
 	}
 
 	return ok, err


### PR DESCRIPTION
If the relative path symbol `.\` is not used, the command looks from the system path rather than relative to the `Dir` parameter, which is also the cause of  ScoopInstaller/Main#5311