### PR TITLE
'nvm use' no longer require administrative rights

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -765,7 +765,7 @@ func use(version string, cpuarch string, reload ...bool) {
 	// Create new symlink
 	var ok bool
 	// ok, err = runElevated(fmt.Sprintf(`"%s" cmd /C mklink /D "%s" "%s"`, filepath.Join(env.root, "elevate.cmd"), filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version)))
-	ok, err = elevatedRun("mklink", "/D", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+	ok, err = elevatedRun("mklink", "/J", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
 	if err != nil {
 		if strings.Contains(err.Error(), "not have sufficient privilege") || strings.Contains(strings.ToLower(err.Error()), "access is denied") {
 			// cmd := exec.Command(filepath.Join(env.root, "elevate.cmd"), "cmd", "/C", "mklink", "/D", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))


### PR DESCRIPTION
'mklink' use '/j' replace '/d' to create directory link, so when use 'nvm use xx.xx.xx', it no longer use administrator privileges. It runs fine in windows 10.