### PR TITLE
Don't perform any changes when trying to use current node version

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -728,6 +728,13 @@ func use(version string, cpuarch string, reload ...bool) {
 		}
 	}
 
+	// Check if a change is needed
+	curVersion, curCpuarch := node.GetCurrentVersion()
+	if version == curVersion && cpuarch == curCpuarch {
+		fmt.Println("node v" + version + " (" + cpuarch + "-bit) is already in use.")
+		return
+	}
+
 	// Make sure the version is installed. If not, warn.
 	if !node.IsVersionInstalled(env.root, version, cpuarch) {
 		fmt.Println("node v" + version + " (" + cpuarch + "-bit) is not installed.")


### PR DESCRIPTION
Implements the change suggested by @danielkcz in #16 (https://github.com/coreybutler/nvm-windows/issues/16#issuecomment-432545211)

Makes it more convenient to automatically switch current node version #