### PR TITLE
Double Slash in URL Bugfix

### DIFF
--- a/src/web/web.go
+++ b/src/web/web.go
@@ -361,7 +361,7 @@ func getNodeUrl(v string, vpre string, arch string, append bool) string {
 	}
 
 	//url := "http://nodejs.org/dist/v"+v+"/" + vpre + "/node.exe"
-	url := GetFullNodeUrl("v" + v + "/" + vpre + "/node.exe")
+	url := GetFullNodeUrl("v" + v + "/" + vpre + "node.exe")
 
 	if !append {
 		version, err := semver.Make(v)


### PR DESCRIPTION
This PR fixes #1179 

As mentioned in [this comment](https://github.com/coreybutler/nvm-windows/issues/1179#issuecomment-2463565838) there's a bug that causes Node versions older than 16.9.0 to have a double slash in their download URL.