### PR TITLE
correct handling of "latest" version in versionNumberFrom function

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -950,6 +950,9 @@ func versionNumberFrom(version string) string {
 
 	if reg.MatchString(version[:1]) {
 		if version[0:1] != "v" {
+			if version == "latest" {
+				return getLatest()
+			}
 			url := web.GetFullNodeUrl("latest-" + version + "/SHASUMS256.txt")
 			remoteContent, err := web.GetRemoteTextFile(url)
 			if err != nil {


### PR DESCRIPTION
# Closing the PR

Upon reviewing my request, I realize that the reported issue was due to a simple typo. I mistakenly wrote "lastest" instead of "latest" in the command nvm install, which led to the 404 error.

After verifying, I found that the functionality works as intended when the command is entered correctly. Therefore, it is unnecessary to pursue this PR.

I will close it to avoid any confusion.