### PR TITLE
nvm 1.2.2 version insert node 14.21.3 error

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -750,7 +750,7 @@ func install(version string, cpuarch string) {
 				defer os.RemoveAll(tempDir)
 
 				// Extract npm to the temp directory
-				err = file.Unzip(filepath.Join(tempDir, "npm-v"+npmv+".zip"), filepath.Join(tempDir, "nvm-npm"))
+				err = file.Unzip(filepath.Join(root+"\\temp", "npm-v"+npmv+".zip"), filepath.Join(tempDir, "nvm-npm"))
 				if err != nil {
 					status <- Status{Err: err}
 				}


### PR DESCRIPTION
nvm.go 753 lines of code file.Unzip(src,dest) `src` read npm-v6.14.18.zip path error

C:\Users\x\AppData\Local\Temp\nvm-npm-2198089316\npm-v6.14.18.zip not npm-v6.14.18.zip
C:\Users\x\AppData\Local\Temp\nvm-install-3650443276\temp\npm-v6.14.18.zip have npm-v6.14.18.zip

<img width="1470" height="205" alt="20250925083320_60_74" src="https://github.com/user-attachments/assets/4c61d1bd-dc16-4f25-bac4-f9dd598d8863" />

Sorry, my English is not very good.
