### PR TITLE
use directory junction to avoid elevated run for non-system path

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -1194,10 +1194,10 @@ func use(version string, cpuarch string, reload ...bool) {
 		// Create new symlink
 		var ok bool
 		// ok, err = runElevated(fmt.Sprintf(`"%s" cmd /C mklink /D "%s" "%s"`, filepath.Join(env.root, "elevate.cmd"), filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version)))
-		ok, err = elevatedRun("mklink", "/D", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+		ok, err = elevatedRun("mklink", "/J", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
 		if err != nil {
 			if strings.Contains(err.Error(), "not have sufficient privilege") || strings.Contains(strings.ToLower(err.Error()), "access is denied") {
-				ok, err = elevatedRun("mklink", "/D", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+				ok, err = elevatedRun("mklink", "/J", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
 				if err != nil {
 					ok = false
 					status <- Status{Err: err, Done: true}


### PR DESCRIPTION
related to #598 #992 #1270 #1022 #724 

I have tried on my PC without turning on developer mode. No admin rights needed to run `nvm use`.